### PR TITLE
✨ Feat: 반려동물 목록 조회 및 빈 상태 UI 구현

### DIFF
--- a/src/features/auth/api/pets.ts
+++ b/src/features/auth/api/pets.ts
@@ -1,15 +1,21 @@
 import { apiClient } from '@/shared/api/axios';
 
-import type { PetFamilyJoinResponse } from '../model/types';
+import type { PetFamilyJoinResponse, PetListResponse } from '../model/types';
 
 interface RequestFamilyJoinOptions {
   /** 가입 단계에서는 registrationToken을 Authorization 헤더로 전달 */
   authToken?: string;
 }
 
+export interface GetPetListParams {
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
 /**
- * 가족 초대 수락 신청 (POST /pets/family)
- * - 초대 코드로 반려동물 가족 등록을 신청한다. 승인 대기 상태.
+ * 가족 초대 수락 요청 (POST /pets/family)
+ * - 초대 코드로 반려동물 가족 등록을 요청한다. 승인 대기 상태.
  */
 export async function requestFamilyJoin(
   code: string,
@@ -26,6 +32,22 @@ export async function requestFamilyJoin(
         : undefined,
     },
   );
+
+  return response.data;
+}
+
+/**
+ * 반려동물 목록 조회 (GET /pets/list)
+ * - 로그인한 사용자의 반려동물 목록을 페이지 단위로 조회한다.
+ */
+export async function getPetList(params?: GetPetListParams): Promise<PetListResponse> {
+  const response = await apiClient.get<PetListResponse>('/pets/list', {
+    params: {
+      page: params?.page ?? 0,
+      size: params?.size ?? 10,
+      sort: params?.sort ?? 'regDate,desc',
+    },
+  });
 
   return response.data;
 }

--- a/src/features/auth/api/pets.ts
+++ b/src/features/auth/api/pets.ts
@@ -45,7 +45,7 @@ export async function getPetList(params?: GetPetListParams): Promise<PetListResp
     params: {
       page: params?.page ?? 0,
       size: params?.size ?? 10,
-      ...(params?.sort ? { sort: params.sort } : {}),
+      sort: params?.sort ?? 'registrationCreatedAt,desc',
     },
   });
 

--- a/src/features/auth/api/pets.ts
+++ b/src/features/auth/api/pets.ts
@@ -45,7 +45,7 @@ export async function getPetList(params?: GetPetListParams): Promise<PetListResp
     params: {
       page: params?.page ?? 0,
       size: params?.size ?? 10,
-      sort: params?.sort ?? 'regDate,desc',
+      ...(params?.sort ? { sort: params.sort } : {}),
     },
   });
 

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -14,6 +14,7 @@ export { AuthErrorScreen } from './ui/status/AuthErrorScreen';
 export { socialLogin, registerProfile, checkNicknameAvailability, updateNotificationSetting } from './api/auth';
 export { getMyProfile } from './api/users';
 export { useCurrentUser } from './model/useCurrentUser';
+export { usePetList } from './model/usePetList';
 export type {
   SocialProvider,
   AuthTokens,
@@ -26,6 +27,8 @@ export type {
   NicknameCheckResponse,
   NotificationUpdateRequest,
   NotificationUpdateResponse,
+  PetListItem,
+  PetListResponse,
   TokenReissueRequest,
   TokenReissueResponse,
   UserProfile,

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -88,6 +88,31 @@ export interface PetFamilyJoinResponse {
 
 // ---- 알림 수신 여부 변경 (PATCH /users/me/setting/notification) ----
 
+export type PetSpecies = 'CANINE' | 'FELINE' | string;
+export type PetSex = 'MALE' | 'FEMALE' | string;
+
+export interface PetListItem {
+  petId: number;
+  petName: string;
+  imageFileUrl: string;
+  species: PetSpecies;
+  breed: string;
+  sex: PetSex;
+  age: number;
+  birth: string;
+  weight: number;
+  registrationNumber: number;
+}
+
+export interface PetListResponse {
+  message: string;
+  pets: PetListItem[];
+  totalPages: number;
+  totalElements: number;
+  currentPage: number;
+  pageSize: number;
+}
+
 export interface NotificationUpdateRequest {
   notificationEnabled: boolean;
 }

--- a/src/features/auth/model/usePetList.ts
+++ b/src/features/auth/model/usePetList.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getPetList, type GetPetListParams } from '@/features/auth/api/pets';
+import { queryKeys } from '@/shared/lib/react-query/queryKey';
+
+export function usePetList(params?: GetPetListParams) {
+  return useQuery({
+    queryKey: queryKeys.pets.list(params),
+    queryFn: () => getPetList(params),
+  });
+}

--- a/src/pages/my/MyDodoPage.tsx
+++ b/src/pages/my/MyDodoPage.tsx
@@ -5,7 +5,16 @@ import { MY_DODO_CONTENT_BY_KEY, getMyDodoMenuHref, getMyDodoMenuKeyFromSearch }
 import { MyDodoLayout } from '@/pages/my/ui/MyDodoLayout';
 import { PetListPanel } from '@/pages/my/ui/PetListPanel';
 import { MyDodoSidebarPanel } from '@/pages/my/ui/MyDodoSidebarPanel';
+import { getApiErrorMessage, getApiErrorStatus } from '@/shared/lib/api/errorMessage';
 import { Skeleton } from '@/shared/ui';
+
+const PET_LIST_STATUS_MESSAGES: Partial<Record<number, string>> = {
+  400: '요청 값을 다시 확인해 주세요.',
+  401: '로그인이 필요합니다. 다시 로그인해 주세요.',
+  403: '반려동물 목록을 조회할 권한이 없습니다.',
+  404: '사용자 정보를 찾을 수 없습니다.',
+  500: '반려동물 목록 조회 중 서버 오류가 발생했습니다.',
+};
 
 function MyDodoContent({
   activeKey,
@@ -102,39 +111,58 @@ function PetListEmptyState() {
   );
 }
 
+function PetListErrorState({ error, onRetry }: { error: unknown; onRetry: () => void }) {
+  const status = getApiErrorStatus(error);
+  const message = getApiErrorMessage(
+    error,
+    '잠시 후 다시 시도해 주세요. 문제가 계속되면 네트워크 상태와 로그인 정보를 함께 확인해 주세요.',
+    PET_LIST_STATUS_MESSAGES,
+  );
+
+  return (
+    <div className="flex min-h-[320px] items-center">
+      <div className="w-full overflow-hidden rounded-[24px] border border-red-100 bg-white">
+        <div className="border-b border-red-100 bg-red-50 px-6 py-5 sm:px-8">
+          <p className="text-xs font-semibold tracking-[0.24em] text-red-500">{status ? `ERROR ${status}` : 'ERROR'}</p>
+          <h1 className="mt-3 text-2xl font-semibold text-neutral-900 sm:text-[28px]">
+            반려동물 목록을 불러오지 못했습니다
+          </h1>
+        </div>
+
+        <div className="px-6 py-8 sm:px-8">
+          <div className="max-w-2xl">
+            <p className="text-sm leading-7 text-neutral-600 sm:text-base">{message}</p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-8 inline-flex min-w-32 items-center justify-center rounded-xl border border-red-200 bg-white px-5 py-3 text-sm font-semibold text-red-500 transition-colors hover:bg-red-50"
+          >
+            다시 시도
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function PetListContent() {
-  const { data, isLoading, isError } = usePetList({ page: 0, size: 10 });
+  const { data, isLoading, isError, error, refetch, isFetching } = usePetList({ page: 0, size: 10 });
 
   if (isLoading) {
     return <MyDodoContent activeKey="pet-list" isLoading />;
   }
 
   if (isError) {
-    return (
-      <div className="flex min-h-[320px] items-center">
-        <div className="w-full overflow-hidden rounded-[24px] border border-red-100 bg-white">
-          <div className="border-b border-red-100 bg-red-50 px-6 py-5 sm:px-8">
-            <p className="text-xs font-semibold tracking-[0.24em] text-red-500">ERROR</p>
-            <h1 className="mt-3 text-2xl font-semibold text-neutral-900 sm:text-[28px]">
-              반려동물 목록을 불러오지 못했습니다
-            </h1>
-          </div>
-
-          <div className="px-6 py-8 sm:px-8">
-            <p className="text-sm leading-7 text-neutral-600 sm:text-base">
-              잠시 후 다시 시도해 주세요. 문제가 계속되면 네트워크 상태와 로그인 정보를 함께 확인해 주세요.
-            </p>
-          </div>
-        </div>
-      </div>
-    );
+    return <PetListErrorState error={error} onRetry={() => void refetch()} />;
   }
 
   if (!data || data.pets.length === 0) {
     return <PetListEmptyState />;
   }
 
-  return <PetListPanel pets={data.pets} totalElements={data.totalElements} />;
+  return <PetListPanel pets={data.pets} totalElements={data.totalElements} isRefreshing={isFetching} />;
 }
 
 export function MyDodoPage() {

--- a/src/pages/my/MyDodoPage.tsx
+++ b/src/pages/my/MyDodoPage.tsx
@@ -29,7 +29,7 @@ function MyDodoContent({
   if (isLoading) {
     return (
       <div className="flex min-h-[320px] items-center">
-        <div className="w-full overflow-hidden rounded-[24px] border border-neutral-200 bg-white">
+        <div className="w-full overflow-hidden rounded-[16px] border border-neutral-200 bg-white">
           <div className="border-b border-neutral-100 bg-gradient-to-r from-brand/8 via-white to-white px-6 py-5 sm:px-8">
             <Skeleton className="h-3 w-14 rounded-md" />
             <Skeleton className="mt-4 h-8 w-64 rounded-lg" />
@@ -42,7 +42,7 @@ function MyDodoContent({
               <Skeleton className="h-4 w-7/12 rounded-md" />
             </div>
 
-            <Skeleton className="mt-8 h-12 w-40 rounded-xl" />
+            <Skeleton className="mt-4 h-12 w-40 rounded-xl" />
           </div>
         </div>
       </div>
@@ -51,7 +51,7 @@ function MyDodoContent({
 
   return (
     <div className="flex min-h-[320px] items-center">
-      <div className="w-full overflow-hidden rounded-[24px] border border-neutral-200 bg-white">
+      <div className="w-full overflow-hidden rounded-[16px] border border-neutral-200 bg-white">
         <div className="border-b border-neutral-100 bg-gradient-to-r from-brand/8 via-white to-white px-6 py-5 sm:px-8">
           <p className="text-xs font-semibold tracking-[0.24em] text-brand">{content.badge}</p>
           <h1 className="mt-3 text-2xl font-semibold text-neutral-900 sm:text-[28px]">{content.title}</h1>
@@ -65,7 +65,7 @@ function MyDodoContent({
           {actionHref ? (
             <Link
               to={actionHref}
-              className="mt-8 inline-flex min-w-40 items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90"
+              className="mt-4 inline-flex min-w-40 items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90"
             >
               {content.actionLabel}
             </Link>
@@ -73,7 +73,7 @@ function MyDodoContent({
             <button
               type="button"
               disabled
-              className="mt-8 inline-flex min-w-40 items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="mt-4 inline-flex min-w-40 items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-medium text-brand-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {content.actionLabel}
             </button>
@@ -86,28 +86,23 @@ function MyDodoContent({
 
 function PetListEmptyState() {
   return (
-    <div className="flex min-h-[320px] items-center">
-      <div className="w-full overflow-hidden rounded-[24px] border border-neutral-200 bg-white">
-        <div className="border-b border-neutral-100 bg-gradient-to-r from-brand/8 via-white to-white px-6 py-5 sm:px-8">
-          <p className="text-xs font-semibold tracking-[0.24em] text-brand">PET</p>
-          <h1 className="mt-3 text-2xl font-semibold text-neutral-900 sm:text-[28px]">등록된 반려동물이 없습니다</h1>
-        </div>
-
-        <div className="px-6 py-10 text-center sm:px-8">
-          <p className="mx-auto max-w-xl text-sm leading-7 text-neutral-600 sm:text-base">
-            반려동물을 등록하면 이곳에서 목록과 상세 정보를 한눈에 관리할 수 있어요.
+    <section className="flex h-full items-start">
+      <div className="w-full overflow-hidden rounded-[16px] border border-neutral-200 bg-white shadow-sm">
+        <div className="bg-[radial-gradient(circle_at_top,rgba(229,108,49,0.1),transparent_40%)] px-6 py-12 text-center sm:px-8 sm:py-14">
+          <p className="text-[16px] font-medium leading-8 text-neutral-950 sm:text-[18px]">
+            현재 등록된 반려동물이 없습니다.
           </p>
 
           <button
             type="button"
             disabled
-            className="mt-8 inline-flex min-w-40 items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="mt-4 inline-flex min-w-56 items-center justify-center rounded-2xl bg-brand px-8 py-4 text-[16px] font-medium text-brand-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-70"
           >
             등록하기
           </button>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -121,7 +116,7 @@ function PetListErrorState({ error, onRetry }: { error: unknown; onRetry: () => 
 
   return (
     <div className="flex min-h-[320px] items-center">
-      <div className="w-full overflow-hidden rounded-[24px] border border-red-100 bg-white">
+      <div className="w-full overflow-hidden rounded-[16px] border border-red-100 bg-white">
         <div className="border-b border-red-100 bg-red-50 px-6 py-5 sm:px-8">
           <p className="text-xs font-semibold tracking-[0.24em] text-red-500">{status ? `ERROR ${status}` : 'ERROR'}</p>
           <h1 className="mt-3 text-2xl font-semibold text-neutral-900 sm:text-[28px]">
@@ -137,7 +132,7 @@ function PetListErrorState({ error, onRetry }: { error: unknown; onRetry: () => 
           <button
             type="button"
             onClick={onRetry}
-            className="mt-8 inline-flex min-w-32 items-center justify-center rounded-xl border border-red-200 bg-white px-5 py-3 text-sm font-semibold text-red-500 transition-colors hover:bg-red-50"
+            className="mt-4 inline-flex min-w-32 items-center justify-center rounded-xl border border-red-200 bg-white px-5 py-3 text-sm font-semibold text-red-500 transition-colors hover:bg-red-50"
           >
             다시 시도
           </button>

--- a/src/pages/my/MyDodoPage.tsx
+++ b/src/pages/my/MyDodoPage.tsx
@@ -1,6 +1,6 @@
 import { Link, useSearchParams } from 'react-router-dom';
 
-import { useCurrentUser } from '@/features/auth/model/useCurrentUser';
+import { useCurrentUser, usePetList } from '@/features/auth';
 import { MY_DODO_CONTENT_BY_KEY, getMyDodoMenuHref, getMyDodoMenuKeyFromSearch } from '@/pages/my/model/menu';
 import { MyDodoLayout } from '@/pages/my/ui/MyDodoLayout';
 import { MyDodoSidebarPanel } from '@/pages/my/ui/MyDodoSidebarPanel';
@@ -74,6 +74,68 @@ function MyDodoContent({
   );
 }
 
+function PetListEmptyState() {
+  return (
+    <div className="flex min-h-[320px] items-center">
+      <div className="w-full overflow-hidden rounded-[24px] border border-neutral-200 bg-white">
+        <div className="border-b border-neutral-100 bg-gradient-to-r from-brand/8 via-white to-white px-6 py-5 sm:px-8">
+          <p className="text-xs font-semibold tracking-[0.24em] text-brand">PET</p>
+          <h1 className="mt-3 text-2xl font-semibold text-neutral-900 sm:text-[28px]">등록된 반려동물이 없습니다</h1>
+        </div>
+
+        <div className="px-6 py-10 text-center sm:px-8">
+          <p className="mx-auto max-w-xl text-sm leading-7 text-neutral-600 sm:text-base">
+            반려동물을 등록하면 이곳에서 목록과 상세 정보를 한눈에 관리할 수 있어요.
+          </p>
+
+          <button
+            type="button"
+            disabled
+            className="mt-8 inline-flex min-w-40 items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            등록하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PetListContent() {
+  const { data, isLoading, isError } = usePetList({ page: 0, size: 10 });
+
+  if (isLoading) {
+    return <MyDodoContent activeKey="pet-list" isLoading />;
+  }
+
+  if (isError) {
+    return (
+      <div className="flex min-h-[320px] items-center">
+        <div className="w-full overflow-hidden rounded-[24px] border border-red-100 bg-white">
+          <div className="border-b border-red-100 bg-red-50 px-6 py-5 sm:px-8">
+            <p className="text-xs font-semibold tracking-[0.24em] text-red-500">ERROR</p>
+            <h1 className="mt-3 text-2xl font-semibold text-neutral-900 sm:text-[28px]">
+              반려동물 목록을 불러오지 못했습니다
+            </h1>
+          </div>
+
+          <div className="px-6 py-8 sm:px-8">
+            <p className="text-sm leading-7 text-neutral-600 sm:text-base">
+              잠시 후 다시 시도해 주세요. 문제가 계속되면 네트워크 상태와 로그인 정보를 함께 확인해 주세요.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.pets.length === 0) {
+    return <PetListEmptyState />;
+  }
+
+  return <MyDodoContent activeKey="pet-list" />;
+}
+
 export function MyDodoPage() {
   const [searchParams] = useSearchParams();
   const activeKey = getMyDodoMenuKeyFromSearch(searchParams.get('menu'));
@@ -90,7 +152,7 @@ export function MyDodoPage() {
           activeKey={activeKey}
         />
       }
-      content={<MyDodoContent activeKey={activeKey} isLoading={isLoading} />}
+      content={activeKey === 'pet-list' ? <PetListContent /> : <MyDodoContent activeKey={activeKey} />}
     />
   );
 }

--- a/src/pages/my/MyDodoPage.tsx
+++ b/src/pages/my/MyDodoPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { useCurrentUser, usePetList } from '@/features/auth';
 import { MY_DODO_CONTENT_BY_KEY, getMyDodoMenuHref, getMyDodoMenuKeyFromSearch } from '@/pages/my/model/menu';
 import { MyDodoLayout } from '@/pages/my/ui/MyDodoLayout';
+import { PetListPanel } from '@/pages/my/ui/PetListPanel';
 import { MyDodoSidebarPanel } from '@/pages/my/ui/MyDodoSidebarPanel';
 import { Skeleton } from '@/shared/ui';
 
@@ -133,7 +134,7 @@ function PetListContent() {
     return <PetListEmptyState />;
   }
 
-  return <MyDodoContent activeKey="pet-list" />;
+  return <PetListPanel pets={data.pets} totalElements={data.totalElements} />;
 }
 
 export function MyDodoPage() {

--- a/src/pages/my/ui/MyDodoLayout.tsx
+++ b/src/pages/my/ui/MyDodoLayout.tsx
@@ -7,9 +7,9 @@ interface MyDodoLayoutProps {
 
 export function MyDodoLayout({ sidebar, content }: MyDodoLayoutProps) {
   return (
-    <div className="flex flex-col gap-5 xl:grid xl:grid-cols-[280px_minmax(0,1fr)] xl:items-start">
+    <div className="flex flex-col gap-5 xl:grid xl:grid-cols-[280px_minmax(0,1fr)] xl:items-stretch">
       <aside className="xl:sticky xl:top-6">{sidebar}</aside>
-      <section className="min-h-[360px] rounded-[24px] border border-neutral-200 bg-white p-6 shadow-sm sm:p-7">
+      <section className="min-h-[360px] rounded-[24px] border border-neutral-200 bg-white p-6 shadow-sm xl:h-full sm:p-7">
         {content}
       </section>
     </div>

--- a/src/pages/my/ui/MyDodoLayout.tsx
+++ b/src/pages/my/ui/MyDodoLayout.tsx
@@ -8,7 +8,7 @@ interface MyDodoLayoutProps {
 export function MyDodoLayout({ sidebar, content }: MyDodoLayoutProps) {
   return (
     <div className="flex flex-col gap-5 xl:grid xl:grid-cols-[280px_minmax(0,1fr)] xl:items-stretch">
-      <aside className="xl:sticky xl:top-6">{sidebar}</aside>
+      <aside className="xl:sticky xl:top-6 xl:self-start">{sidebar}</aside>
       <section className="min-h-[360px] rounded-[24px] border border-neutral-200 bg-white p-6 shadow-sm xl:h-full sm:p-7">
         {content}
       </section>

--- a/src/pages/my/ui/MyDodoSidebarPanel.tsx
+++ b/src/pages/my/ui/MyDodoSidebarPanel.tsx
@@ -19,7 +19,7 @@ export function MyDodoSidebarPanel({
   activeKey,
 }: MyDodoSidebarPanelProps) {
   return (
-    <div className="rounded-[24px] border border-neutral-200 bg-white px-5 py-6 shadow-sm">
+    <div className="h-full rounded-[24px] border border-neutral-200 bg-white px-5 py-6 shadow-sm">
       <MyDodoProfileCard user={user} profileUrl={profileUrl} displayName={displayName} isLoading={isLoading} />
       <MyDodoSidebar activeKey={activeKey} />
     </div>

--- a/src/pages/my/ui/PetListPanel.tsx
+++ b/src/pages/my/ui/PetListPanel.tsx
@@ -27,6 +27,7 @@ function PetImage({ src, alt }: { src: string; alt: string }) {
         alt={alt}
         className="h-full w-full object-cover"
         onError={(event) => {
+          event.currentTarget.onerror = null;
           event.currentTarget.src = profileDefaultIllustration;
         }}
       />

--- a/src/pages/my/ui/PetListPanel.tsx
+++ b/src/pages/my/ui/PetListPanel.tsx
@@ -4,6 +4,7 @@ import type { PetListItem } from '@/features/auth/model/types';
 interface PetListPanelProps {
   pets: PetListItem[];
   totalElements: number;
+  isRefreshing?: boolean;
 }
 
 function formatSexLabel(sex: string) {
@@ -71,7 +72,7 @@ function PetListCard({ pet }: { pet: PetListItem }) {
   );
 }
 
-export function PetListPanel({ pets, totalElements }: PetListPanelProps) {
+export function PetListPanel({ pets, totalElements, isRefreshing = false }: PetListPanelProps) {
   return (
     <div className="space-y-6">
       <div className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white">
@@ -84,8 +85,11 @@ export function PetListPanel({ pets, totalElements }: PetListPanelProps) {
                 등록된 반려동물 정보를 이곳에서 한눈에 확인할 수 있어요.
               </p>
             </div>
-            <div className="rounded-full bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-700">
-              총 {totalElements}마리
+            <div className="flex items-center gap-2">
+              {isRefreshing ? <span className="text-xs font-medium text-neutral-400">새로 불러오는 중...</span> : null}
+              <div className="rounded-full bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-700">
+                총 {totalElements}마리
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/my/ui/PetListPanel.tsx
+++ b/src/pages/my/ui/PetListPanel.tsx
@@ -8,9 +8,9 @@ interface PetListPanelProps {
 }
 
 function formatSexLabel(sex: string) {
-  if (sex === 'MALE') return '수컷';
-  if (sex === 'FEMALE') return '암컷';
-  return sex;
+  if (sex === 'MALE') return '♂';
+  if (sex === 'FEMALE') return '♀';
+  return '';
 }
 
 function formatSpeciesLabel(species: string) {
@@ -21,7 +21,7 @@ function formatSpeciesLabel(species: string) {
 
 function PetImage({ src, alt }: { src: string; alt: string }) {
   return (
-    <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100">
+    <div className="flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-[24px] bg-neutral-100 sm:h-28 sm:w-28">
       <img
         src={src || profileDefaultIllustration}
         alt={alt}
@@ -34,72 +34,111 @@ function PetImage({ src, alt }: { src: string; alt: string }) {
   );
 }
 
-function PetListCard({ pet }: { pet: PetListItem }) {
+function ActionButton({ label, disabled = true }: { label: string; disabled?: boolean }) {
   return (
-    <article className="rounded-[22px] border border-neutral-200 bg-white p-5 transition-colors hover:border-brand/40">
-      <div className="flex items-start gap-4">
-        <PetImage src={pet.imageFileUrl} alt={pet.petName} />
+    <button
+      type="button"
+      disabled={disabled}
+      className="inline-flex h-16 w-full items-center justify-center rounded-[20px] border border-neutral-200 bg-white px-5 text-[18px] font-semibold text-neutral-900 transition-colors hover:border-brand/50 disabled:cursor-not-allowed disabled:opacity-70 sm:w-44"
+    >
+      {label}
+    </button>
+  );
+}
 
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold text-neutral-900">{pet.petName}</h2>
-            <span className="rounded-full bg-brand/8 px-2.5 py-1 text-xs font-semibold text-brand">
-              {formatSpeciesLabel(pet.species)}
-            </span>
+function HeroPetCard({ pet, isPrimary }: { pet: PetListItem; isPrimary: boolean }) {
+  return (
+    <article className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white shadow-sm">
+      <div className="flex flex-col gap-5 px-5 py-5 sm:px-6 sm:py-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <PetImage src={pet.imageFileUrl} alt={pet.petName} />
+
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-[18px] font-semibold text-neutral-950 sm:text-[20px]">
+                {pet.petName}
+                <span className="ml-1 text-rose-300">{formatSexLabel(pet.sex)}</span>
+              </h2>
+              {isPrimary ? (
+                <span className="rounded-full bg-brand/8 px-2.5 py-1 text-[11px] font-semibold tracking-[0.12em] text-brand">
+                  대표 반려동물
+                </span>
+              ) : null}
+            </div>
+
+            <div className="mt-3 space-y-1.5 text-[18px] font-semibold text-neutral-900">
+              <p>
+                {pet.birth} <span className="font-medium text-neutral-500">(만 {pet.age}세)</span>
+              </p>
+              <p>
+                {formatSpeciesLabel(pet.species)} <span className="font-medium text-neutral-500">{pet.breed}</span>
+              </p>
+              <p>{pet.weight} kg</p>
+            </div>
           </div>
+        </div>
 
-          <p className="mt-2 text-sm text-neutral-500">
-            {pet.breed} · {formatSexLabel(pet.sex)} · {pet.age}살
-          </p>
-
-          <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm text-neutral-600 sm:grid-cols-4">
-            <div>
-              <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Birth</dt>
-              <dd className="mt-1">{pet.birth}</dd>
-            </div>
-            <div>
-              <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Weight</dt>
-              <dd className="mt-1">{pet.weight}kg</dd>
-            </div>
-            <div className="col-span-2 sm:col-span-2">
-              <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Registration</dt>
-              <dd className="mt-1 break-all">{pet.registrationNumber}</dd>
-            </div>
-          </dl>
+        <div className="flex flex-col gap-3 sm:items-end">
+          <ActionButton label="상세 정보" />
+          <ActionButton label="체중 관리" />
         </div>
       </div>
     </article>
   );
 }
 
+function AddPetCard() {
+  return (
+    <section className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white shadow-sm">
+      <div className="bg-[radial-gradient(circle_at_top,rgba(229,108,49,0.1),transparent_42%)] px-6 py-12 text-center sm:px-8">
+        <p className="text-[18px] font-semibold leading-8 text-neutral-950 sm:text-[20px]">
+          반려동물을 더 키우고 계신가요?
+          <br />
+          리스트에 더 추가해 보세요 :D
+        </p>
+
+        <button
+          type="button"
+          disabled
+          className="mt-8 inline-flex min-w-60 items-center justify-center rounded-2xl bg-brand px-8 py-4 text-[18px] font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          등록하기
+        </button>
+      </div>
+    </section>
+  );
+}
+
 export function PetListPanel({ pets, totalElements, isRefreshing = false }: PetListPanelProps) {
+  const [primaryPet, ...restPets] = pets;
+
   return (
     <div className="space-y-6">
-      <div className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white">
-        <div className="border-b border-neutral-100 bg-gradient-to-r from-brand/8 via-white to-white px-6 py-5 sm:px-8">
-          <p className="text-xs font-semibold tracking-[0.24em] text-brand">PET LIST</p>
-          <div className="mt-3 flex flex-wrap items-end justify-between gap-3">
-            <div>
-              <h1 className="text-2xl font-semibold text-neutral-900 sm:text-[28px]">반려동물 리스트</h1>
-              <p className="mt-2 text-sm leading-6 text-neutral-500">
-                등록된 반려동물 정보를 이곳에서 한눈에 확인할 수 있어요.
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              {isRefreshing ? <span className="text-xs font-medium text-neutral-400">새로 불러오는 중...</span> : null}
-              <div className="rounded-full bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-700">
-                총 {totalElements}마리
-              </div>
-            </div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-[18px] font-semibold text-neutral-950 sm:text-[20px]">반려동물 리스트</h1>
+          <p className="mt-1 text-sm text-neutral-500">등록된 반려동물 정보를 한눈에 확인할 수 있어요.</p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {isRefreshing ? <span className="text-xs font-medium text-neutral-400">새로 불러오는 중...</span> : null}
+          <div className="rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-sm font-medium text-neutral-600">
+            총 {totalElements}마리
           </div>
         </div>
       </div>
 
-      <div className="grid gap-4">
-        {pets.map((pet) => (
-          <PetListCard key={pet.petId} pet={pet} />
-        ))}
-      </div>
+      {primaryPet ? <HeroPetCard pet={primaryPet} isPrimary /> : null}
+
+      {restPets.length > 0 ? (
+        <div className="grid gap-4">
+          {restPets.map((pet) => (
+            <HeroPetCard key={pet.petId} pet={pet} isPrimary={false} />
+          ))}
+        </div>
+      ) : null}
+
+      <AddPetCard />
     </div>
   );
 }

--- a/src/pages/my/ui/PetListPanel.tsx
+++ b/src/pages/my/ui/PetListPanel.tsx
@@ -1,0 +1,101 @@
+import profileDefaultIllustration from '@/features/auth/assets/profile-default.svg';
+import type { PetListItem } from '@/features/auth/model/types';
+
+interface PetListPanelProps {
+  pets: PetListItem[];
+  totalElements: number;
+}
+
+function formatSexLabel(sex: string) {
+  if (sex === 'MALE') return '수컷';
+  if (sex === 'FEMALE') return '암컷';
+  return sex;
+}
+
+function formatSpeciesLabel(species: string) {
+  if (species === 'CANINE') return '강아지';
+  if (species === 'FELINE') return '고양이';
+  return species;
+}
+
+function PetImage({ src, alt }: { src: string; alt: string }) {
+  return (
+    <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100">
+      <img
+        src={src || profileDefaultIllustration}
+        alt={alt}
+        className="h-full w-full object-cover"
+        onError={(event) => {
+          event.currentTarget.src = profileDefaultIllustration;
+        }}
+      />
+    </div>
+  );
+}
+
+function PetListCard({ pet }: { pet: PetListItem }) {
+  return (
+    <article className="rounded-[22px] border border-neutral-200 bg-white p-5 transition-colors hover:border-brand/40">
+      <div className="flex items-start gap-4">
+        <PetImage src={pet.imageFileUrl} alt={pet.petName} />
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-xl font-semibold text-neutral-900">{pet.petName}</h2>
+            <span className="rounded-full bg-brand/8 px-2.5 py-1 text-xs font-semibold text-brand">
+              {formatSpeciesLabel(pet.species)}
+            </span>
+          </div>
+
+          <p className="mt-2 text-sm text-neutral-500">
+            {pet.breed} · {formatSexLabel(pet.sex)} · {pet.age}살
+          </p>
+
+          <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm text-neutral-600 sm:grid-cols-4">
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Birth</dt>
+              <dd className="mt-1">{pet.birth}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Weight</dt>
+              <dd className="mt-1">{pet.weight}kg</dd>
+            </div>
+            <div className="col-span-2 sm:col-span-2">
+              <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Registration</dt>
+              <dd className="mt-1 break-all">{pet.registrationNumber}</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function PetListPanel({ pets, totalElements }: PetListPanelProps) {
+  return (
+    <div className="space-y-6">
+      <div className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white">
+        <div className="border-b border-neutral-100 bg-gradient-to-r from-brand/8 via-white to-white px-6 py-5 sm:px-8">
+          <p className="text-xs font-semibold tracking-[0.24em] text-brand">PET LIST</p>
+          <div className="mt-3 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h1 className="text-2xl font-semibold text-neutral-900 sm:text-[28px]">반려동물 리스트</h1>
+              <p className="mt-2 text-sm leading-6 text-neutral-500">
+                등록된 반려동물 정보를 이곳에서 한눈에 확인할 수 있어요.
+              </p>
+            </div>
+            <div className="rounded-full bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-700">
+              총 {totalElements}마리
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4">
+        {pets.map((pet) => (
+          <PetListCard key={pet.petId} pet={pet} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/lib/react-query/queryKey.ts
+++ b/src/shared/lib/react-query/queryKey.ts
@@ -1,7 +1,7 @@
 export const queryKeys = {
   pets: {
     list: (params?: { page?: number; size?: number; sort?: string }) =>
-      ['pets', 'list', params?.page ?? 0, params?.size ?? 10, params?.sort ?? 'regDate,desc'] as const,
+      ['pets', 'list', params?.page ?? 0, params?.size ?? 10, params?.sort ?? 'registrationCreatedAt,desc'] as const,
     detail: (petId: number) => ['pets', petId, 'detail'] as const,
     significantList: (petId: number) => ['pets', petId, 'significant', 'list'] as const,
   },

--- a/src/shared/lib/react-query/queryKey.ts
+++ b/src/shared/lib/react-query/queryKey.ts
@@ -1,15 +1,8 @@
-// queryKey는 데이터의 이름표다!!!!!!!!!
-// as const를 사용하면 타입이 튼튼해져서 오타/구조 깨짐을 줄일 수 있다!!!
-
-/**
- * 쿼리 키 정의
- * - 각 쿼리마다 고유한 키를 정의하여 데이터 캐싱 및 관리에 사용
- * - ex. ['users', userId] -> 특정 사용자 데이터를 가져오는 쿼리 키
- */
 export const queryKeys = {
   pets: {
-    list: ['pets', 'list'] as const, // 반려동물 조회 목록
-    detail: (petId: number) => ['pets', petId, 'detail'] as const, // 반려동물 상세 조회
-    significantList: (petId: number) => ['pets', petId, 'significant', 'list'] as const, // 펫 특이사항 목록 조회
+    list: (params?: { page?: number; size?: number; sort?: string }) =>
+      ['pets', 'list', params?.page ?? 0, params?.size ?? 10, params?.sort ?? 'regDate,desc'] as const,
+    detail: (petId: number) => ['pets', petId, 'detail'] as const,
+    significantList: (petId: number) => ['pets', petId, 'significant', 'list'] as const,
   },
 } as const;


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 반려동물 목록 조회 API 및 usePetList 훅 추가
- 마이도도 반려동물 리스트에 로딩/에러/빈 상태/목록 UI 연결
- 반려동물 미등록 상태 UI 및 등록된 반려동물 카드 UI 구현
- 상태코드 기반 에러 안내와 재시도 버튼 추가
- 기본 정렬 파라미터 및 UI 스타일 일관성 정리

<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #28 

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [ ] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [ ] 관련 이슈를 연결했습니다.
-   [ ] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [ ] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [ ] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)
<img width="2126" height="1392" alt="image" src="https://github.com/user-attachments/assets/33454990-b9ba-42df-bda7-d9b40119990d" />

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- `/my?menu=pet-list` 진입 후 빈 상태 / 목록 상태 UI 확인
- 목록 조회 중 스켈레톤 노출 확인
- 조회 실패 시 에러 문구 및 재시도 버튼 동작 확인
- Network 탭에서 `/pets/list` 요청 파라미터와 응답 상태 확인