### PR TITLE
🐞 Fix: 세션 만료 후 재로그인 및 복귀 흐름 개선

### DIFF
--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import { refreshAccessToken } from '@/shared/lib/auth/refreshSession';
+import { redirectToLogin, refreshAccessToken } from '@/shared/lib/auth/refreshSession';
 import { getAccessToken, getRefreshToken, isAccessTokenExpired } from '@/shared/lib/auth/token';
 import { Header } from '@/widgets/header';
 
@@ -10,7 +10,15 @@ export function AppLayout() {
     if (!getAccessToken() || !getRefreshToken() || !isAccessTokenExpired()) {
       return;
     }
-    void refreshAccessToken();
+
+    const refreshSession = async () => {
+      const refreshedToken = await refreshAccessToken();
+      if (!refreshedToken) {
+        redirectToLogin();
+      }
+    };
+
+    void refreshSession();
   }, []);
 
   return (

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,7 +1,15 @@
 export { LoginModal } from './ui/LoginModal';
 export { SocialLoginButton } from './ui/SocialLoginButton';
 export { SignupFlow } from './ui/signup';
-export { redirectToSocialLogin, getStoredState, clearStoredState, parseProvider } from './lib/oauth';
+export {
+  redirectToSocialLogin,
+  getStoredState,
+  clearStoredState,
+  parseProvider,
+  getStoredReturnTo,
+  setStoredReturnTo,
+  clearStoredReturnTo,
+} from './lib/oauth';
 export {
   resolveApiAuthError,
   resolveAuthErrorFromMessage,

--- a/src/features/auth/lib/authErrorPresentation.ts
+++ b/src/features/auth/lib/authErrorPresentation.ts
@@ -14,87 +14,87 @@ export interface AuthErrorPresentation {
 
 const HTTP_PRESENTATION: Record<number, Omit<AuthErrorPresentation, 'message' | 'statusCode'>> = {
   400: {
-    badge: '400',
-    title: '요청을 처리할 수 없어요',
-    hint: '입력·로그인 과정을 처음부터 다시 시도해주세요.',
+    badge: '요청 확인',
+    title: '요청을 다시 확인해주세요',
+    hint: '입력값이나 로그인 흐름이 중간에 바뀌었을 수 있어요. 처음부터 다시 시도해주세요.',
   },
   401: {
-    badge: '401',
-    title: '로그인에 실패했어요',
-    hint: '소셜 계정으로 다시 로그인해주세요.',
+    badge: '인증 필요',
+    title: '로그인이 필요해요',
+    hint: '세션이 만료되었거나 인증 정보가 유효하지 않을 수 있어요.',
   },
   403: {
-    badge: '403',
-    title: '이용이 제한된 계정이에요',
-    hint: '정지·휴면 계정은 고객센터로 문의해주세요.',
+    badge: '접근 제한',
+    title: '현재 계정으로는 이용할 수 없어요',
+    hint: '권한이 맞지 않거나 추가 확인이 필요한 상태일 수 있어요.',
   },
   404: {
-    badge: '404',
-    title: '계정을 찾을 수 없어요',
-    hint: '다른 소셜 계정으로 가입했을 수 있어요.',
+    badge: '계정 확인',
+    title: '계정 정보를 찾지 못했어요',
+    hint: '다른 소셜 계정으로 가입했는지 확인해보세요.',
   },
   409: {
-    badge: '409',
-    title: '요청을 완료할 수 없어요',
-    hint: '이미 처리된 요청일 수 있어요.',
+    badge: '중복 요청',
+    title: '이미 처리된 요청일 수 있어요',
+    hint: '같은 작업이 먼저 처리되었는지 확인한 뒤 다시 시도해주세요.',
   },
   429: {
-    badge: '429',
-    title: '잠시만 기다려주세요',
-    hint: '요청이 너무 많아요. 1~2분 뒤 다시 시도해주세요.',
+    badge: '잠시 후',
+    title: '요청이 잠시 많아졌어요',
+    hint: '1~2분 뒤 다시 시도하면 더 안정적으로 연결될 가능성이 높아요.',
   },
   500: {
-    badge: '500',
-    title: '서버에 문제가 있어요',
-    hint: '잠시 후 다시 시도해주세요.',
+    badge: '서버 점검',
+    title: '서버에서 문제가 발생했어요',
+    hint: '잠시 뒤 다시 시도해주세요. 문제가 계속되면 운영팀 확인이 필요할 수 있어요.',
   },
 };
 
 const CLIENT_ERRORS: Record<AuthClientErrorCode, AuthErrorPresentation> = {
   invalid_provider: {
-    badge: '안내',
-    title: '지원하지 않는 로그인이에요',
-    message: '네이버 또는 구글 로그인만 이용할 수 있어요.',
-    hint: '홈에서 다시 시작해주세요.',
+    badge: '로그인 안내',
+    title: '지원하지 않는 로그인 방식이에요',
+    message: '현재는 네이버와 구글 로그인만 지원하고 있어요.',
+    hint: '이전 화면으로 돌아가서 다시 선택해주세요.',
     statusCode: null,
   },
   missing_code: {
-    badge: '안내',
-    title: '로그인이 중단됐어요',
-    message: '인가 코드를 받지 못했어요.',
-    hint: '소셜 로그인을 처음부터 다시 시도해주세요.',
+    badge: '인증 중단',
+    title: '로그인이 중간에 멈췄어요',
+    message: '소셜 인증 코드를 받지 못했어요.',
+    hint: '브라우저 뒤로가기를 누르지 말고, 처음부터 다시 시도해주세요.',
     statusCode: null,
   },
   invalid_state: {
-    badge: '안내',
-    title: '잘못된 접근이에요',
-    message: '보안 검증에 실패했어요.',
-    hint: '브라우저 뒤로가기 없이 홈에서 다시 로그인해주세요.',
+    badge: '보안 확인',
+    title: '로그인 검증에 실패했어요',
+    message: '보안 검증을 완료하지 못해 로그인을 이어갈 수 없어요.',
+    hint: '탭을 오래 열어두었거나 인증 흐름이 중간에 바뀌었을 수 있어요.',
     statusCode: null,
   },
 };
 
 const SESSION_EXPIRED: AuthErrorPresentation = {
-  badge: '세션',
-  title: '로그인이 만료됐어요',
-  message: '안전을 위해 다시 로그인해주세요.',
-  hint: '오래된 탭이거나 토큰이 만료됐을 수 있어요.',
+  badge: '다시 인증',
+  title: '로그인이 만료되었어요',
+  message: '안전한 이용을 위해 한 번 더 로그인해주세요.',
+  hint: '오래된 탭을 다시 열었거나, 토큰 유효 시간이 지나 세션이 종료되었을 수 있어요.',
   statusCode: 401,
 };
 
 const NETWORK_PRESENTATION: AuthErrorPresentation = {
-  badge: '연결',
-  title: '네트워크를 확인해주세요',
+  badge: '연결 확인',
+  title: '네트워크 연결을 확인해주세요',
   message: '서버와 연결하지 못했어요.',
-  hint: '인터넷 연결 후 다시 시도해주세요.',
+  hint: '인터넷 연결 상태를 확인한 뒤 다시 시도해주세요.',
   statusCode: null,
 };
 
 const TIMEOUT_PRESENTATION: AuthErrorPresentation = {
-  badge: '시간',
-  title: '응답이 지연되고 있어요',
-  message: '요청 시간이 초과됐어요.',
-  hint: '잠시 후 다시 시도해주세요.',
+  badge: '응답 지연',
+  title: '응답이 조금 늦어지고 있어요',
+  message: '요청 시간이 초과되었어요.',
+  hint: '네트워크 상태가 안정된 뒤 다시 시도해주세요.',
   statusCode: null,
 };
 
@@ -113,7 +113,7 @@ function presentationFromStatus(
   }
 
   return {
-    badge: String(status),
+    badge: `오류 ${status}`,
     title: '문제가 발생했어요',
     message,
     statusCode: status,
@@ -155,7 +155,7 @@ export function resolveApiAuthError(
   }
 
   return {
-    badge: '오류',
+    badge: '알 수 없음',
     title: '문제가 발생했어요',
     message,
     statusCode: null,
@@ -168,7 +168,7 @@ export function resolveAuthErrorFromMessage(message: string, statusCode?: number
   }
 
   return {
-    badge: '오류',
+    badge: '일시 오류',
     title: '문제가 발생했어요',
     message,
     statusCode: null,

--- a/src/features/auth/lib/oauth.ts
+++ b/src/features/auth/lib/oauth.ts
@@ -3,12 +3,16 @@ import { env } from '@/shared/config';
 import type { SocialProvider } from '../model/types';
 
 const OAUTH_STATE_KEY = 'oauth_state';
+const OAUTH_RETURN_TO_KEY = 'oauth_return_to';
 
 interface ProviderOAuthConfig {
   authorizeUrl: string;
   clientId: string;
-  /** 요청할 사용자 정보 범위 (구글 등에서 사용) */
   scope?: string;
+}
+
+interface RedirectToSocialLoginOptions {
+  returnTo?: string | null;
 }
 
 const PROVIDER_OAUTH: Record<SocialProvider, ProviderOAuthConfig> = {
@@ -23,35 +27,51 @@ const PROVIDER_OAUTH: Record<SocialProvider, ProviderOAuthConfig> = {
   },
 };
 
-// provider별 redirect_uri. OAuth 콘솔에 등록된 값과 정확히 일치해야 함
 function getRedirectUri(provider: SocialProvider): string {
   return `${env.OAUTH_REDIRECT_URI}/${provider.toLowerCase()}`;
 }
 
-// URL 경로 파라미터("google"/"naver")를 SocialProvider로 변환. 유효하지 않으면 null.
+function isSafeReturnPath(value: string | null | undefined): value is string {
+  return Boolean(value && value.startsWith('/') && !value.startsWith('//'));
+}
+
 export function parseProvider(value: string | undefined): SocialProvider | null {
   const upper = value?.toUpperCase();
   return upper === 'GOOGLE' || upper === 'NAVER' ? upper : null;
 }
 
-// CSRF 방지용 랜덤 state를 생성하고 sessionStorage에 저장
 function createState(): string {
   const state = crypto.randomUUID();
   sessionStorage.setItem(OAUTH_STATE_KEY, state);
   return state;
 }
 
-// 콜백에서 검증할 수 있도록 저장된 state를 반환
 export function getStoredState(): string | null {
   return sessionStorage.getItem(OAUTH_STATE_KEY);
 }
 
-// 사용 후 state를 제거
 export function clearStoredState(): void {
   sessionStorage.removeItem(OAUTH_STATE_KEY);
 }
 
-// provider 인증 페이지 URL을 조립
+export function setStoredReturnTo(path: string | null | undefined): void {
+  if (!isSafeReturnPath(path)) {
+    sessionStorage.removeItem(OAUTH_RETURN_TO_KEY);
+    return;
+  }
+
+  sessionStorage.setItem(OAUTH_RETURN_TO_KEY, path);
+}
+
+export function getStoredReturnTo(): string | null {
+  const value = sessionStorage.getItem(OAUTH_RETURN_TO_KEY);
+  return isSafeReturnPath(value) ? value : null;
+}
+
+export function clearStoredReturnTo(): void {
+  sessionStorage.removeItem(OAUTH_RETURN_TO_KEY);
+}
+
 export function buildSocialAuthUrl(provider: SocialProvider): string {
   const config = PROVIDER_OAUTH[provider];
 
@@ -69,7 +89,10 @@ export function buildSocialAuthUrl(provider: SocialProvider): string {
   return `${config.authorizeUrl}?${params.toString()}`;
 }
 
-// provider 로그인 페이지로 이동
-export function redirectToSocialLogin(provider: SocialProvider): void {
+export function redirectToSocialLogin(provider: SocialProvider, options?: RedirectToSocialLoginOptions): void {
+  if (options?.returnTo !== undefined) {
+    setStoredReturnTo(options.returnTo);
+  }
+
   window.location.href = buildSocialAuthUrl(provider);
 }

--- a/src/features/auth/ui/status/AuthErrorScreen.tsx
+++ b/src/features/auth/ui/status/AuthErrorScreen.tsx
@@ -14,10 +14,10 @@ interface AuthErrorScreenProps {
 }
 
 function badgeTone(statusCode: number | null): string {
-  if (statusCode === 403) return 'bg-red-50 text-red-700 ring-red-100';
-  if (statusCode === 429) return 'bg-amber-50 text-amber-800 ring-amber-100';
-  if (statusCode !== null && statusCode >= 500) return 'bg-neutral-100 text-neutral-700 ring-neutral-200';
-  return 'bg-orange-50 text-brand ring-orange-100';
+  if (statusCode === 403) return 'border-red-200 bg-red-50 text-red-700';
+  if (statusCode === 429) return 'border-amber-200 bg-amber-50 text-amber-800';
+  if (statusCode !== null && statusCode >= 500) return 'border-neutral-200 bg-neutral-100 text-neutral-700';
+  return 'border-orange-200 bg-orange-50 text-brand';
 }
 
 export function AuthErrorScreen({
@@ -28,55 +28,77 @@ export function AuthErrorScreen({
   showHomeLink = true,
   onHomeClick,
 }: AuthErrorScreenProps) {
-  const { badge, title, message, hint, statusCode } = presentation;
+  const { badge, title, message, hint } = presentation;
 
   return (
-    <div className="flex flex-1 flex-col items-center justify-center px-6 py-10 font-sans">
-      <div className="flex w-full max-w-md flex-col items-center gap-8 text-center">
+    <div className="relative flex flex-1 items-center justify-center overflow-hidden px-6 py-12 font-sans">
+      <div
+        className="absolute left-1/2 top-16 h-48 w-48 -translate-x-[130%] rounded-full bg-brand/8 blur-3xl"
+        aria-hidden
+      />
+      <div
+        className="absolute left-1/2 top-32 h-56 w-56 translate-x-[45%] rounded-full bg-secondary/12 blur-3xl"
+        aria-hidden
+      />
+
+      <div className="relative w-full max-w-[38rem] overflow-hidden rounded-[36px] border border-white/70 bg-white/90 p-6 shadow-[0_32px_100px_rgba(15,23,42,0.12)] backdrop-blur sm:p-8">
         <div
-          className={`inline-flex min-h-14 min-w-14 items-center justify-center rounded-2xl px-3 text-lg font-semibold tracking-tight ring-1 ${badgeTone(statusCode)}`}
+          className="absolute inset-x-10 top-0 h-px bg-linear-to-r from-transparent via-brand/25 to-transparent"
           aria-hidden
-        >
-          {badge}
-        </div>
+        />
 
-        <div className="flex max-w-sm flex-col gap-2">
-          <h1 className="text-[20px] font-semibold tracking-tight text-neutral-900 sm:text-[22px]">{title}</h1>
-          <p className="text-[14px] font-normal leading-relaxed text-neutral-600 sm:text-[15px]">{message}</p>
-          {hint ? <p className="text-[12px] leading-relaxed text-neutral-500 sm:text-[13px]">{hint}</p> : null}
-        </div>
+        <div className="flex flex-col items-center text-center">
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.18em] uppercase ${badgeTone(
+              presentation.statusCode,
+            )}`}
+          >
+            <span className="h-2 w-2 rounded-full bg-current opacity-70" aria-hidden />
+            {badge}
+          </span>
 
-        <div className="flex w-full max-w-xs flex-col gap-3">
-          {primaryAction}
+          <div className="mt-8 space-y-4">
+            <h1 className="text-[2rem] font-semibold tracking-[-0.04em] text-neutral-950 sm:text-[2.5rem]">{title}</h1>
+            <p className="mx-auto max-w-[32rem] text-[1.05rem] leading-8 text-neutral-700 sm:text-[1.1rem]">
+              {message}
+            </p>
+            {hint ? (
+              <p className="mx-auto max-w-[30rem] text-sm leading-7 text-neutral-500 sm:text-[15px]">{hint}</p>
+            ) : null}
+          </div>
 
-          {onRetrySocial && retryProvider ? (
-            <button
-              type="button"
-              onClick={() => onRetrySocial(retryProvider)}
-              className="h-12 w-full cursor-pointer rounded-xl bg-brand text-sm font-medium text-brand-foreground transition-opacity hover:opacity-90"
-            >
-              {retryProvider === 'NAVER' ? '네이버' : '구글'}로 다시 로그인
-            </button>
-          ) : null}
+          <div className="mt-10 w-full max-w-md space-y-3">
+            {primaryAction}
 
-          {showHomeLink ? (
-            onHomeClick ? (
+            {onRetrySocial && retryProvider ? (
               <button
                 type="button"
-                onClick={onHomeClick}
-                className="inline-flex h-12 items-center justify-center rounded-xl border border-neutral-200 bg-white text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-50"
+                onClick={() => onRetrySocial(retryProvider)}
+                className="inline-flex h-12 w-full items-center justify-center rounded-2xl border border-brand/15 bg-brand/5 px-4 text-sm font-medium text-brand transition-colors hover:bg-brand/10"
               >
-                홈으로 돌아가기
+                {retryProvider === 'NAVER' ? '네이버' : '구글'}로 바로 다시 로그인
               </button>
-            ) : (
-              <Link
-                to="/"
-                className="inline-flex h-12 items-center justify-center rounded-xl border border-neutral-200 bg-white text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-50"
-              >
-                홈으로 돌아가기
-              </Link>
-            )
-          ) : null}
+            ) : null}
+
+            {showHomeLink ? (
+              onHomeClick ? (
+                <button
+                  type="button"
+                  onClick={onHomeClick}
+                  className="inline-flex h-14 w-full items-center justify-center rounded-2xl border border-neutral-200 bg-white px-4 text-base font-medium text-neutral-700 transition-colors hover:border-neutral-300 hover:bg-neutral-50"
+                >
+                  홈으로 돌아가기
+                </button>
+              ) : (
+                <Link
+                  to="/"
+                  className="inline-flex h-14 w-full items-center justify-center rounded-2xl border border-neutral-200 bg-white px-4 text-base font-medium text-neutral-700 transition-colors hover:border-neutral-300 hover:bg-neutral-50"
+                >
+                  홈으로 돌아가기
+                </Link>
+              )
+            ) : null}
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/auth/ui/status/AuthErrorScreen.tsx
+++ b/src/features/auth/ui/status/AuthErrorScreen.tsx
@@ -6,12 +6,11 @@ import type { SocialProvider } from '../../model/types';
 
 interface AuthErrorScreenProps {
   presentation: AuthErrorPresentation;
-  /** 주 버튼 (다시 로그인 등) */
   primaryAction?: ReactNode;
-  /** provider가 있으면 소셜 재시도 버튼 노출 */
   onRetrySocial?: (provider: SocialProvider) => void;
   retryProvider?: SocialProvider | null;
   showHomeLink?: boolean;
+  onHomeClick?: () => void;
 }
 
 function badgeTone(statusCode: number | null): string {
@@ -27,6 +26,7 @@ export function AuthErrorScreen({
   onRetrySocial,
   retryProvider,
   showHomeLink = true,
+  onHomeClick,
 }: AuthErrorScreenProps) {
   const { badge, title, message, hint, statusCode } = presentation;
 
@@ -60,12 +60,22 @@ export function AuthErrorScreen({
           ) : null}
 
           {showHomeLink ? (
-            <Link
-              to="/"
-              className="inline-flex h-12 items-center justify-center rounded-xl border border-neutral-200 bg-white text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-50"
-            >
-              홈으로 돌아가기
-            </Link>
+            onHomeClick ? (
+              <button
+                type="button"
+                onClick={onHomeClick}
+                className="inline-flex h-12 items-center justify-center rounded-xl border border-neutral-200 bg-white text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-50"
+              >
+                홈으로 돌아가기
+              </button>
+            ) : (
+              <Link
+                to="/"
+                className="inline-flex h-12 items-center justify-center rounded-xl border border-neutral-200 bg-white text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-50"
+              >
+                홈으로 돌아가기
+              </Link>
+            )
           ) : null}
         </div>
       </div>

--- a/src/pages/auth/AuthCallbackPage.tsx
+++ b/src/pages/auth/AuthCallbackPage.tsx
@@ -4,7 +4,9 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import {
   AuthErrorScreen,
   AuthLoadingScreen,
+  clearStoredReturnTo,
   clearStoredState,
+  getStoredReturnTo,
   getStoredState,
   parseProvider,
   redirectToSocialLogin,
@@ -44,6 +46,7 @@ export function AuthCallbackPage() {
       const code = searchParams.get('code');
       const state = searchParams.get('state');
       const storedState = getStoredState();
+      const returnTo = getStoredReturnTo();
       clearStoredState();
 
       if (provider) {
@@ -73,18 +76,21 @@ export function AuthCallbackPage() {
 
         if (result.kind === 'LOGIN') {
           setTokens(result.data);
-          navigate('/', { replace: true });
-        } else {
-          navigate('/auth/signup', {
-            replace: true,
-            state: {
-              registrationToken: result.data.registrationToken,
-              email: result.data.email,
-              name: result.data.name,
-              profileUrl: result.data.profileUrl,
-            },
-          });
+          const nextPath = returnTo ?? '/';
+          clearStoredReturnTo();
+          navigate(nextPath, { replace: true });
+          return;
         }
+
+        navigate('/auth/signup', {
+          replace: true,
+          state: {
+            registrationToken: result.data.registrationToken,
+            email: result.data.email,
+            name: result.data.name,
+            profileUrl: result.data.profileUrl,
+          },
+        });
       } catch (error) {
         console.error('[social-login] 실패', error);
         setStatus('error');
@@ -95,7 +101,7 @@ export function AuthCallbackPage() {
     };
 
     void processCallback();
-  }, [providerParam, searchParams, navigate]);
+  }, [navigate, providerParam, searchParams]);
 
   const provider = parseProvider(providerParam);
   const providerLabel = provider ? PROVIDER_LABEL[provider] : null;
@@ -112,8 +118,8 @@ export function AuthCallbackPage() {
 
   return (
     <AuthLoadingScreen
-      title="로그인 처리 중"
-      message="소셜 계정 정보를 확인하고 있어요."
+      title="로그인을 확인하고 있어요"
+      message="선택한 소셜 계정 정보를 안전하게 불러오는 중입니다."
       stepLabel={providerLabel ? `${providerLabel} 로그인 연동 중` : undefined}
     />
   );

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,19 +1,26 @@
 import { useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { LoginModal, redirectToSocialLogin, resolveSessionExpiredError } from '@/features/auth';
 import { AuthErrorScreen } from '@/features/auth/ui/status/AuthErrorScreen';
 import DoDoLogo from '@/shared/assets/images/Logo_light.svg?react';
+import { clearTokens } from '@/shared/lib/auth/token';
 
 const sessionExpiredButtonClassName =
   'group relative h-14 w-full overflow-hidden rounded-2xl bg-linear-to-r from-brand via-[#f08b57] to-[#f6b93b] px-4 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(229,108,49,0.34)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_20px_48px_rgba(229,108,49,0.42)]';
 
 export function LoginPage() {
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
   const [isLoginOpen, setIsLoginOpen] = useState(false);
 
   const sessionExpired = searchParams.get('reason') === 'session-expired';
   const errorPresentation = useMemo(() => (sessionExpired ? resolveSessionExpiredError() : null), [sessionExpired]);
+
+  const handleGoHomeAsGuest = () => {
+    clearTokens();
+    navigate('/', { replace: true });
+  };
 
   if (sessionExpired && errorPresentation) {
     return (
@@ -21,6 +28,7 @@ export function LoginPage() {
         <AuthErrorScreen
           presentation={errorPresentation}
           showHomeLink
+          onHomeClick={handleGoHomeAsGuest}
           primaryAction={
             <button type="button" onClick={() => setIsLoginOpen(true)} className={sessionExpiredButtonClassName}>
               <span className="absolute inset-0 bg-linear-to-r from-white/0 via-white/18 to-white/0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -5,6 +5,9 @@ import { LoginModal, redirectToSocialLogin, resolveSessionExpiredError } from '@
 import { AuthErrorScreen } from '@/features/auth/ui/status/AuthErrorScreen';
 import DoDoLogo from '@/shared/assets/images/Logo_light.svg?react';
 
+const sessionExpiredButtonClassName =
+  'group relative h-14 w-full overflow-hidden rounded-2xl bg-linear-to-r from-brand via-[#f08b57] to-[#f6b93b] px-4 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(229,108,49,0.34)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_20px_48px_rgba(229,108,49,0.42)]';
+
 export function LoginPage() {
   const [searchParams] = useSearchParams();
   const [isLoginOpen, setIsLoginOpen] = useState(false);
@@ -14,20 +17,26 @@ export function LoginPage() {
 
   if (sessionExpired && errorPresentation) {
     return (
-      <AuthErrorScreen
-        presentation={errorPresentation}
-        onRetrySocial={redirectToSocialLogin}
-        showHomeLink
-        primaryAction={
-          <button
-            type="button"
-            onClick={() => setIsLoginOpen(true)}
-            className="h-12 w-full cursor-pointer rounded-xl bg-brand text-sm font-medium text-brand-foreground transition-opacity hover:opacity-90"
-          >
-            다시 로그인하기
-          </button>
-        }
-      />
+      <>
+        <AuthErrorScreen
+          presentation={errorPresentation}
+          showHomeLink
+          primaryAction={
+            <button type="button" onClick={() => setIsLoginOpen(true)} className={sessionExpiredButtonClassName}>
+              <span className="absolute inset-0 bg-linear-to-r from-white/0 via-white/18 to-white/0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+              <span className="absolute -right-8 top-0 h-full w-20 rotate-12 bg-white/12 blur-2xl transition-transform duration-500 group-hover:-translate-x-4" />
+              <span className="relative flex items-center justify-center gap-2">
+                <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-white/18 text-base">
+                  *
+                </span>
+                <span>다시 로그인하기</span>
+              </span>
+            </button>
+          }
+        />
+
+        <LoginModal open={isLoginOpen} onClose={() => setIsLoginOpen(false)} onSelectProvider={redirectToSocialLogin} />
+      </>
     );
   }
 
@@ -36,8 +45,8 @@ export function LoginPage() {
       <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6 py-10 text-center font-sans">
         <DoDoLogo className="h-12 w-auto" />
         <div className="flex max-w-sm flex-col gap-2">
-          <h1 className="text-[20px] font-semibold tracking-tight text-neutral-900">DoDo에 오신 것을 환영해요</h1>
-          <p className="text-[14px] font-normal text-neutral-500">네이버·구글 계정으로 간편하게 시작할 수 있어요.</p>
+          <h1 className="text-[20px] font-semibold tracking-tight text-neutral-900">DoDo와 함께 시작해보세요</h1>
+          <p className="text-[14px] font-normal text-neutral-500">네이버와 구글 계정으로 간편하게 시작할 수 있어요.</p>
         </div>
         <button
           type="button"
@@ -49,11 +58,6 @@ export function LoginPage() {
         <Link to="/" className="text-sm text-neutral-500 underline-offset-2 hover:text-brand hover:underline">
           홈으로
         </Link>
-        {import.meta.env.DEV ? (
-          <Link to="/auth/signup?preview=1" className="text-xs text-amber-700 underline">
-            회원가입 UI 미리보기 (dev)
-          </Link>
-        ) : null}
       </div>
 
       <LoginModal open={isLoginOpen} onClose={() => setIsLoginOpen(false)} onSelectProvider={redirectToSocialLogin} />

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams, type Location } from 'react-router-dom';
 
-import { LoginModal, redirectToSocialLogin, resolveSessionExpiredError } from '@/features/auth';
+import { LoginModal, clearStoredReturnTo, redirectToSocialLogin, resolveSessionExpiredError } from '@/features/auth';
 import { AuthErrorScreen } from '@/features/auth/ui/status/AuthErrorScreen';
 import DoDoLogo from '@/shared/assets/images/Logo_light.svg?react';
 import { clearTokens } from '@/shared/lib/auth/token';
@@ -45,6 +45,7 @@ export function LoginPage() {
   const returnTo = resolveReturnTo(searchParams.get('from'), locationState?.from);
 
   const handleGoHomeAsGuest = () => {
+    clearStoredReturnTo();
     clearTokens();
     navigate('/', { replace: true });
   };

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -16,10 +16,15 @@ export function LoginPage() {
 
   const sessionExpired = searchParams.get('reason') === 'session-expired';
   const errorPresentation = useMemo(() => (sessionExpired ? resolveSessionExpiredError() : null), [sessionExpired]);
+  const returnTo = searchParams.get('from');
 
   const handleGoHomeAsGuest = () => {
     clearTokens();
     navigate('/', { replace: true });
+  };
+
+  const handleSelectProvider = (provider: 'NAVER' | 'GOOGLE') => {
+    redirectToSocialLogin(provider, { returnTo: sessionExpired ? returnTo : null });
   };
 
   if (sessionExpired && errorPresentation) {
@@ -34,8 +39,11 @@ export function LoginPage() {
               <span className="absolute inset-0 bg-linear-to-r from-white/0 via-white/18 to-white/0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
               <span className="absolute -right-8 top-0 h-full w-20 rotate-12 bg-white/12 blur-2xl transition-transform duration-500 group-hover:-translate-x-4" />
               <span className="relative flex items-center justify-center gap-2">
-                <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-white/18 text-base">
-                  *
+                <span
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-white/18 text-base"
+                  aria-hidden
+                >
+                  ✦
                 </span>
                 <span>다시 로그인하기</span>
               </span>
@@ -43,7 +51,7 @@ export function LoginPage() {
           }
         />
 
-        <LoginModal open={isLoginOpen} onClose={() => setIsLoginOpen(false)} onSelectProvider={redirectToSocialLogin} />
+        <LoginModal open={isLoginOpen} onClose={() => setIsLoginOpen(false)} onSelectProvider={handleSelectProvider} />
       </>
     );
   }
@@ -68,7 +76,7 @@ export function LoginPage() {
         </Link>
       </div>
 
-      <LoginModal open={isLoginOpen} onClose={() => setIsLoginOpen(false)} onSelectProvider={redirectToSocialLogin} />
+      <LoginModal open={isLoginOpen} onClose={() => setIsLoginOpen(false)} onSelectProvider={handleSelectProvider} />
     </>
   );
 }

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useSearchParams, type Location } from 'react-router-dom';
 
 import { LoginModal, redirectToSocialLogin, resolveSessionExpiredError } from '@/features/auth';
 import { AuthErrorScreen } from '@/features/auth/ui/status/AuthErrorScreen';
@@ -9,14 +9,40 @@ import { clearTokens } from '@/shared/lib/auth/token';
 const sessionExpiredButtonClassName =
   'group relative h-14 w-full overflow-hidden rounded-2xl bg-linear-to-r from-brand via-[#f08b57] to-[#f6b93b] px-4 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(229,108,49,0.34)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_20px_48px_rgba(229,108,49,0.42)]';
 
+interface LoginLocationState {
+  from?: Pick<Location, 'pathname' | 'search' | 'hash'>;
+}
+
+function isSafeReturnPath(path: string | null | undefined): path is string {
+  return Boolean(path && path.startsWith('/') && !path.startsWith('//'));
+}
+
+function resolveReturnTo(
+  queryFrom: string | null,
+  stateFrom: Pick<Location, 'pathname' | 'search' | 'hash'> | undefined,
+): string | null {
+  if (isSafeReturnPath(queryFrom)) {
+    return queryFrom;
+  }
+
+  if (!stateFrom) {
+    return null;
+  }
+
+  const path = `${stateFrom.pathname}${stateFrom.search}${stateFrom.hash}`;
+  return isSafeReturnPath(path) ? path : null;
+}
+
 export function LoginPage() {
   const [searchParams] = useSearchParams();
+  const location = useLocation();
   const navigate = useNavigate();
   const [isLoginOpen, setIsLoginOpen] = useState(false);
 
   const sessionExpired = searchParams.get('reason') === 'session-expired';
   const errorPresentation = useMemo(() => (sessionExpired ? resolveSessionExpiredError() : null), [sessionExpired]);
-  const returnTo = searchParams.get('from');
+  const locationState = location.state as LoginLocationState | null;
+  const returnTo = resolveReturnTo(searchParams.get('from'), locationState?.from);
 
   const handleGoHomeAsGuest = () => {
     clearTokens();
@@ -24,7 +50,7 @@ export function LoginPage() {
   };
 
   const handleSelectProvider = (provider: 'NAVER' | 'GOOGLE') => {
-    redirectToSocialLogin(provider, { returnTo: sessionExpired ? returnTo : null });
+    redirectToSocialLogin(provider, { returnTo });
   };
 
   if (sessionExpired && errorPresentation) {

--- a/src/shared/lib/auth/refreshSession.ts
+++ b/src/shared/lib/auth/refreshSession.ts
@@ -13,7 +13,6 @@ interface ReissueResponse {
 let refreshPromise: Promise<string | null> | null = null;
 let isRedirecting = false;
 
-/** refreshToken으로 accessToken 재발급 (동시 요청은 한 번만 호출) */
 export async function refreshAccessToken(): Promise<string | null> {
   if (refreshPromise) {
     return refreshPromise;
@@ -52,8 +51,10 @@ export async function refreshAccessToken(): Promise<string | null> {
 export function redirectToLogin(): void {
   if (typeof window === 'undefined') return;
   if (isRedirecting) return;
-  const path = window.location.pathname;
-  if (path.startsWith('/auth')) return;
+
+  const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (window.location.pathname.startsWith('/auth')) return;
+
   isRedirecting = true;
   window.location.assign(`/auth?reason=session-expired&from=${encodeURIComponent(path)}`);
 }

--- a/src/shared/lib/auth/token.ts
+++ b/src/shared/lib/auth/token.ts
@@ -1,12 +1,5 @@
-// 인증 토큰 저장소 — 키 문자열은 여기서만 관리
-//
-// 저장 전략 (XSS 완화, 백엔드 쿠키 전환 전):
-// - accessToken: localStorage (apiClient·RequireAuth가 읽음)
-// - refreshToken: sessionStorage (탭 종료 시 제거, localStorage보다 노출 범위 축소)
-// TODO(보안 강화): 백엔드 httpOnly 쿠키 지원 시 refreshToken은 쿠키로, accessToken도 쿠키 검토
-
 const ACCESS_TOKEN_KEY = 'accessToken';
-/** @deprecated 마이그레이션용 — 신규 저장은 sessionStorage만 사용 */
+/** @deprecated migration-only legacy key */
 const LEGACY_REFRESH_TOKEN_KEY = 'refreshToken';
 const REFRESH_TOKEN_KEY = 'dodo.refreshToken';
 const PROFILE_URL_KEY = 'profileUrl';
@@ -14,14 +7,14 @@ const NICKNAME_KEY = 'nickname';
 const NOTIFICATION_ENABLED_KEY = 'notificationEnabled';
 const ACCESS_TOKEN_EXPIRES_AT_KEY = 'accessTokenExpiresAt';
 const ACCESS_TOKEN_TTL_MS_KEY = 'accessTokenTtlMs';
+const AUTH_STATE_EVENT = 'dodo:auth-state-change';
 
-/** 만료 N ms 전에 선제 갱신 (TTL 대비 cap 적용) */
+/** Refresh before expiry with a bounded TTL-based buffer. */
 export const ACCESS_TOKEN_REFRESH_BUFFER_MS = 60_000;
 
 interface StoredAuth {
   accessToken: string;
   refreshToken: string;
-  /** 소셜 로그인·가입 응답 — 밀리초 (OpenAPI SocialLoginResponse) */
   accessTokenExpiresIn: number;
   profileUrl: string;
   nickname?: string;
@@ -30,7 +23,6 @@ interface StoredAuth {
 interface ReissueTokens {
   accessToken: string;
   refreshToken: string;
-  /** POST /auth/reissue 응답 — 초 단위 (OpenAPI TokenResponse) */
   accessTokenExpiresIn: number;
 }
 
@@ -38,7 +30,12 @@ function readRefreshFromSession(): string | null {
   return sessionStorage.getItem(REFRESH_TOKEN_KEY);
 }
 
-/** 예전 localStorage refreshToken → sessionStorage로 1회 이전 */
+function notifyAuthStateChanged(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(AUTH_STATE_EVENT));
+}
+
+/** Migrate legacy localStorage refresh token into sessionStorage once. */
 function migrateLegacyRefreshToken(): void {
   const legacy = localStorage.getItem(LEGACY_REFRESH_TOKEN_KEY);
   if (!legacy) return;
@@ -47,6 +44,7 @@ function migrateLegacyRefreshToken(): void {
     sessionStorage.setItem(REFRESH_TOKEN_KEY, legacy);
   }
   localStorage.removeItem(LEGACY_REFRESH_TOKEN_KEY);
+  notifyAuthStateChanged();
 }
 
 migrateLegacyRefreshToken();
@@ -67,12 +65,47 @@ function getRefreshBufferMs(): number {
   if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
     return ACCESS_TOKEN_REFRESH_BUFFER_MS;
   }
+
   return Math.min(ACCESS_TOKEN_REFRESH_BUFFER_MS, Math.max(5_000, Math.floor(ttlMs * 0.1)));
+}
+
+export function subscribeAuthState(listener: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (!event.key) {
+      listener();
+      return;
+    }
+
+    if (
+      event.key === ACCESS_TOKEN_KEY ||
+      event.key === LEGACY_REFRESH_TOKEN_KEY ||
+      event.key === PROFILE_URL_KEY ||
+      event.key === NICKNAME_KEY ||
+      event.key === NOTIFICATION_ENABLED_KEY ||
+      event.key === ACCESS_TOKEN_EXPIRES_AT_KEY ||
+      event.key === ACCESS_TOKEN_TTL_MS_KEY
+    ) {
+      listener();
+    }
+  };
+
+  window.addEventListener(AUTH_STATE_EVENT, listener);
+  window.addEventListener('storage', handleStorage);
+
+  return () => {
+    window.removeEventListener(AUTH_STATE_EVENT, listener);
+    window.removeEventListener('storage', handleStorage);
+  };
 }
 
 export function getAccessTokenExpiresAt(): number | null {
   const raw = localStorage.getItem(ACCESS_TOKEN_EXPIRES_AT_KEY);
   if (!raw) return null;
+
   const parsed = Number(raw);
   return Number.isFinite(parsed) ? parsed : null;
 }
@@ -80,12 +113,13 @@ export function getAccessTokenExpiresAt(): number | null {
 export function isAccessTokenExpired(bufferMs = getRefreshBufferMs()): boolean {
   const expiresAt = getAccessTokenExpiresAt();
   if (expiresAt === null) return false;
+
   const remaining = expiresAt - Date.now();
   if (remaining <= 0) return true;
+
   return remaining <= bufferMs;
 }
 
-// 로그인/가입 완료 응답 — accessTokenExpiresIn은 밀리초 (OpenAPI SocialLoginResponse)
 export function setTokens(auth: StoredAuth): void {
   localStorage.setItem(ACCESS_TOKEN_KEY, auth.accessToken);
   setRefreshToken(auth.refreshToken);
@@ -96,13 +130,14 @@ export function setTokens(auth: StoredAuth): void {
   }
 
   setAccessTokenExpiry(auth.accessTokenExpiresIn);
+  notifyAuthStateChanged();
 }
 
-/** POST /auth/reissue 응답 — accessTokenExpiresIn은 초 단위 (OpenAPI TokenResponse) */
 export function setReissueTokens(tokens: ReissueTokens): void {
   localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken);
   setRefreshToken(tokens.refreshToken);
   setAccessTokenExpiry(tokens.accessTokenExpiresIn * 1000);
+  notifyAuthStateChanged();
 }
 
 export function getAccessToken(): string | null {
@@ -123,6 +158,7 @@ export function getNickname(): string | null {
 
 export function setNotificationEnabled(enabled: boolean): void {
   localStorage.setItem(NOTIFICATION_ENABLED_KEY, enabled ? 'true' : 'false');
+  notifyAuthStateChanged();
 }
 
 export function getNotificationEnabled(): boolean | null {
@@ -132,7 +168,6 @@ export function getNotificationEnabled(): boolean | null {
   return null;
 }
 
-/** GET /users/me 응답으로 localStorage 프로필 캐시를 갱신 */
 export function syncUserProfile(profile: {
   profileUrl?: string;
   nickname?: string;
@@ -149,16 +184,16 @@ export function syncUserProfile(profile: {
   }
 
   if (profile.notificationEnabled !== undefined) {
-    setNotificationEnabled(profile.notificationEnabled);
+    localStorage.setItem(NOTIFICATION_ENABLED_KEY, profile.notificationEnabled ? 'true' : 'false');
   }
+
+  notifyAuthStateChanged();
 }
 
-/** access + refresh 모두 있을 때만 true (reissue 가능한 완전한 세션) */
 export function hasAuthSession(): boolean {
   return Boolean(getAccessToken()) && Boolean(getRefreshToken());
 }
 
-// 저장된 모든 인증 정보를 제거(로그아웃·갱신 실패 등)
 export function clearTokens(): void {
   localStorage.removeItem(ACCESS_TOKEN_KEY);
   localStorage.removeItem(LEGACY_REFRESH_TOKEN_KEY);
@@ -168,4 +203,5 @@ export function clearTokens(): void {
   localStorage.removeItem(NOTIFICATION_ENABLED_KEY);
   localStorage.removeItem(ACCESS_TOKEN_EXPIRES_AT_KEY);
   localStorage.removeItem(ACCESS_TOKEN_TTL_MS_KEY);
+  notifyAuthStateChanged();
 }

--- a/src/widgets/header/model/useIsLoggedIn.ts
+++ b/src/widgets/header/model/useIsLoggedIn.ts
@@ -1,9 +1,11 @@
-import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useSyncExternalStore } from 'react';
 
-import { getAccessToken } from '@/shared/lib/auth/token';
+import { getAccessToken, subscribeAuthState } from '@/shared/lib/auth/token';
+
+function getLoggedInSnapshot(): boolean {
+  return typeof window !== 'undefined' && Boolean(getAccessToken());
+}
 
 export function useIsLoggedIn() {
-  const location = useLocation();
-  return useMemo(() => typeof window !== 'undefined' && Boolean(getAccessToken()), [location.pathname]);
+  return useSyncExternalStore(subscribeAuthState, getLoggedInSnapshot, () => false);
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 세션 만료 화면에서 `다시 로그인하기` 버튼이 실제로 로그인 모달을 열도록 수정
- 세션 만료 화면의 문구와 레이아웃을 다듬어 안내 UX 개선
- `홈으로 돌아가기` 클릭 시 인증 토큰을 정리하고 비로그인 상태의 메인(`/`)으로 이동하도록 수정
- 토큰 제거 후 헤더 등 인증 UI가 즉시 갱신되도록 인증 상태 반응성 개선
- 앱 초기 진입 시 만료된 토큰으로 재발급이 실패하는 경우에도 동일한 세션 만료 UX로 연결되도록 정리
- 세션 만료 후 다시 로그인하면 기존에 접근하던 경로로 복귀할 수 있도록 OAuth `returnTo` 흐름 추가


<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Fixes: #40 

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)


<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.
