### PR TITLE
✨ Feat: 마이도도 회원정보 수정 기능 구현

### DIFF
--- a/src/features/auth/api/users.ts
+++ b/src/features/auth/api/users.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '@/shared/api/axios';
 
-import type { UserProfile } from '../model/types';
+import type { UpdateMyProfileRequest, UpdateMyProfileResponse, UserProfile } from '../model/types';
 
 /**
  * 내 정보 조회 (GET /users/me)
@@ -8,5 +8,14 @@ import type { UserProfile } from '../model/types';
  */
 export async function getMyProfile(): Promise<UserProfile> {
   const response = await apiClient.get<UserProfile>('/users/me');
+  return response.data;
+}
+
+/**
+ * 내 정보 수정 (PATCH /users/me)
+ * - 현재 로그인한 사용자의 닉네임, 지역, 가족 여부를 수정
+ */
+export async function updateMyProfile(body: UpdateMyProfileRequest): Promise<UpdateMyProfileResponse> {
+  const response = await apiClient.patch<UpdateMyProfileResponse>('/users/me', body);
   return response.data;
 }

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -20,7 +20,7 @@ export type { AuthErrorPresentation, AuthClientErrorCode, AuthErrorContext } fro
 export { AuthLoadingScreen } from './ui/status/AuthLoadingScreen';
 export { AuthErrorScreen } from './ui/status/AuthErrorScreen';
 export { socialLogin, registerProfile, checkNicknameAvailability, updateNotificationSetting } from './api/auth';
-export { getMyProfile } from './api/users';
+export { getMyProfile, updateMyProfile } from './api/users';
 export { useCreatePet } from './model/useCreatePet';
 export { useCreatePetInvitationCode } from './model/useCreatePetInvitationCode';
 export { useCreatePetSpecialNote } from './model/useCreatePetSpecialNote';
@@ -76,6 +76,8 @@ export type {
   NicknameCheckResponse,
   NotificationUpdateRequest,
   NotificationUpdateResponse,
+  UpdateMyProfileRequest,
+  UpdateMyProfileResponse,
   PetDetailResponse,
   PetFamilyApprovalAction,
   PetFamilyApprovalRequest,
@@ -102,5 +104,6 @@ export {
   SOCIAL_LOGIN_STATUS_MESSAGES,
   REGISTER_PROFILE_STATUS_MESSAGES,
   NOTIFICATION_SETTING_STATUS_MESSAGES,
+  PROFILE_UPDATE_STATUS_MESSAGES,
   NICKNAME_CHECK_STATUS_MESSAGES,
 } from './lib/apiErrorMessages';

--- a/src/features/auth/lib/apiErrorMessages.ts
+++ b/src/features/auth/lib/apiErrorMessages.ts
@@ -1,17 +1,17 @@
 /** 소셜 로그인 POST /auth/social-login */
 export const SOCIAL_LOGIN_STATUS_MESSAGES: Partial<Record<number, string>> = {
-  400: '잘못된 요청이에요. 다시 로그인해주세요.',
+  400: '잘못된 로그인 요청이에요. 다시 로그인해주세요.',
   401: '로그인 정보가 올바르지 않아요. 다시 시도해주세요.',
-  403: '정지되었거나 휴면 상태인 계정이에요.',
+  403: '접근이 제한된 계정이에요.',
   404: '가입된 계정을 찾을 수 없어요.',
   429: '요청이 너무 많아요. 잠시 후 다시 시도해주세요.',
   500: '서버 오류가 발생했어요. 잠시 후 다시 시도해주세요.',
 };
 
-/** 가입 완료 PUT /users/me/profile */
+/** 회원가입 완료 PUT /users/me/profile */
 export const REGISTER_PROFILE_STATUS_MESSAGES: Partial<Record<number, string>> = {
-  400: '입력 정보를 확인해주세요.',
-  401: '가입 시간이 만료됐어요. 처음부터 다시 로그인해주세요.',
+  400: '입력 정보를 다시 확인해주세요.',
+  401: '가입 세션이 만료되었어요. 처음부터 다시 로그인해주세요.',
   409: '이미 사용 중인 닉네임이에요.',
   500: '회원가입에 실패했어요. 잠시 후 다시 시도해주세요.',
 };
@@ -22,7 +22,16 @@ export const NOTIFICATION_SETTING_STATUS_MESSAGES: Partial<Record<number, string
   500: '알림 설정 변경에 실패했어요. 잠시 후 다시 시도해주세요.',
 };
 
-/** 닉네임 중복 확인 GET /users/nickname/check (400 외) */
+/** 내 정보 수정 PATCH /users/me */
+export const PROFILE_UPDATE_STATUS_MESSAGES: Partial<Record<number, string>> = {
+  400: '입력한 회원정보를 다시 확인해주세요.',
+  401: '로그인이 필요해요. 다시 로그인한 뒤 시도해주세요.',
+  404: '사용자 정보를 찾을 수 없어요.',
+  409: '이미 사용 중인 닉네임이에요.',
+  500: '회원정보 수정에 실패했어요. 잠시 후 다시 시도해주세요.',
+};
+
+/** 닉네임 중복 확인 GET /users/nickname/check */
 export const NICKNAME_CHECK_STATUS_MESSAGES: Partial<Record<number, string>> = {
   500: '중복 확인에 실패했어요. 잠시 후 다시 시도해주세요.',
 };

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -389,6 +389,24 @@ export interface NotificationUpdateResponse {
 
 // ---- 내 정보 조회 (GET /users/me) ----
 
+export interface UpdateMyProfileRequest {
+  nickname: string;
+  region: string;
+  hasFamily: boolean;
+}
+
+export interface UpdateMyProfileResponse {
+  message: string;
+  email: string;
+  name: string;
+  nickname: string;
+  region: string;
+  hasFamily: boolean;
+  profileUrl: string;
+  notificationEnabled: boolean;
+  userCreatedAt: string;
+}
+
 export interface UserProfile {
   message: string;
   email: string;

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -393,6 +393,7 @@ export interface UpdateMyProfileRequest {
   nickname: string;
   region: string;
   hasFamily: boolean;
+  profileUrl?: string | null;
 }
 
 export interface UpdateMyProfileResponse {

--- a/src/features/auth/model/useCurrentUser.ts
+++ b/src/features/auth/model/useCurrentUser.ts
@@ -23,16 +23,30 @@ interface UseCurrentUserResult {
   displayName: string;
 }
 
+function trimOrNull(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
 export function useCurrentUser(): UseCurrentUserResult {
   const [user, setUser] = useState<UserProfile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [, setAuthStateVersion] = useState(0);
   const accessToken = getAccessToken();
   const hasToken = Boolean(accessToken);
 
   useEffect(() => {
     return subscribeAuthState(() => {
-      setAuthStateVersion((prev) => prev + 1);
+      setUser((current) => {
+        if (!current) return current;
+
+        return {
+          ...current,
+          nickname: trimOrNull(getNickname()) ?? current.nickname,
+          profileUrl: trimOrNull(getProfileUrl()) ?? current.profileUrl,
+          region: trimOrNull(getRegion()) ?? current.region,
+          notificationEnabled: getNotificationEnabled() ?? current.notificationEnabled,
+        };
+      });
     });
   }, []);
 
@@ -54,7 +68,7 @@ export function useCurrentUser(): UseCurrentUserResult {
         syncUserProfile(profile);
         setUser(profile);
       } catch (error) {
-        console.error('[users/me] 조회 실패', error);
+        console.error('[users/me] failed', error);
         if (!cancelled) {
           setUser(null);
         }
@@ -73,10 +87,10 @@ export function useCurrentUser(): UseCurrentUserResult {
   }, [accessToken]);
 
   const activeUser = hasToken ? user : null;
-  const profileUrl = activeUser?.profileUrl?.trim() || getProfileUrl();
-  const nickname = activeUser?.nickname?.trim() || getNickname();
-  const region = activeUser?.region?.trim() || getRegion();
-  const notificationEnabled = activeUser?.notificationEnabled ?? getNotificationEnabled();
+  const profileUrl = trimOrNull(getProfileUrl()) ?? trimOrNull(activeUser?.profileUrl) ?? null;
+  const nickname = trimOrNull(getNickname()) ?? trimOrNull(activeUser?.nickname) ?? null;
+  const region = trimOrNull(getRegion()) ?? trimOrNull(activeUser?.region) ?? null;
+  const notificationEnabled = getNotificationEnabled() ?? activeUser?.notificationEnabled ?? null;
   const displayName = nickname ? `${nickname}님` : '회원님';
 
   return {

--- a/src/features/auth/model/useCurrentUser.ts
+++ b/src/features/auth/model/useCurrentUser.ts
@@ -6,6 +6,7 @@ import {
   getNotificationEnabled,
   getProfileUrl,
   getRegion,
+  subscribeAuthState,
   syncUserProfile,
 } from '@/shared/lib/auth/token';
 
@@ -25,8 +26,15 @@ interface UseCurrentUserResult {
 export function useCurrentUser(): UseCurrentUserResult {
   const [user, setUser] = useState<UserProfile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [, setAuthStateVersion] = useState(0);
   const accessToken = getAccessToken();
   const hasToken = Boolean(accessToken);
+
+  useEffect(() => {
+    return subscribeAuthState(() => {
+      setAuthStateVersion((prev) => prev + 1);
+    });
+  }, []);
 
   useEffect(() => {
     if (!accessToken) {

--- a/src/features/auth/model/useCurrentUser.ts
+++ b/src/features/auth/model/useCurrentUser.ts
@@ -5,6 +5,7 @@ import {
   getNickname,
   getNotificationEnabled,
   getProfileUrl,
+  getRegion,
   syncUserProfile,
 } from '@/shared/lib/auth/token';
 
@@ -66,7 +67,7 @@ export function useCurrentUser(): UseCurrentUserResult {
   const activeUser = hasToken ? user : null;
   const profileUrl = activeUser?.profileUrl?.trim() || getProfileUrl();
   const nickname = activeUser?.nickname?.trim() || getNickname();
-  const region = activeUser?.region?.trim() || null;
+  const region = activeUser?.region?.trim() || getRegion();
   const notificationEnabled = activeUser?.notificationEnabled ?? getNotificationEnabled();
   const displayName = nickname ? `${nickname}님` : '회원님';
 

--- a/src/features/auth/ui/signup/RegionSelectModal.tsx
+++ b/src/features/auth/ui/signup/RegionSelectModal.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import { Modal } from '@/shared/ui';
 import {
   formatRegionLabel,
   getSigunguList,
@@ -8,6 +7,7 @@ import {
   parseRegionLabel,
   SIDO_LIST,
 } from '@/shared/lib/regions';
+import { Modal } from '@/shared/ui';
 
 import { PrimaryButton } from './SignupStepLayout';
 import { SignupSelect } from './SignupSelect';
@@ -33,9 +33,8 @@ function RegionSelectForm({
   const [sigungu, setSigungu] = useState(parsed.sigungu ?? '');
 
   const sigunguOptions = sido ? getSigunguList(sido) : [];
-  const showSigungu = sido && hasSigunguOptions(sido);
-
-  const canConfirm = sido && (!showSigungu || sigungu);
+  const showSigungu = Boolean(sido) && hasSigunguOptions(sido);
+  const canConfirm = Boolean(sido) && (!showSigungu || Boolean(sigungu));
 
   const handleSidoChange = (nextSido: string) => {
     setSido(nextSido);
@@ -49,7 +48,7 @@ function RegionSelectForm({
   };
 
   return (
-    <>
+    <div className="max-h-[calc(100vh-8rem)] overflow-y-auto pr-1">
       <h2 className="pr-8 text-lg font-semibold text-neutral-900">지역 선택</h2>
       <p className="mt-1 text-sm text-neutral-500">활동 지역을 선택해주세요.</p>
 
@@ -57,7 +56,7 @@ function RegionSelectForm({
         <SignupSelect
           id="region-sido"
           label="시/도"
-          placeholder="시/도 선택"
+          placeholder="시/도를 선택해주세요"
           value={sido}
           options={SIDO_LIST}
           onChange={handleSidoChange}
@@ -67,7 +66,7 @@ function RegionSelectForm({
           <SignupSelect
             id="region-sigungu"
             label="시/군/구"
-            placeholder="시/군/구 선택"
+            placeholder="시/군/구를 선택해주세요"
             value={sigungu}
             options={sigunguOptions}
             onChange={setSigungu}
@@ -82,13 +81,13 @@ function RegionSelectForm({
           선택 완료
         </PrimaryButton>
       </div>
-    </>
+    </div>
   );
 }
 
 export function RegionSelectModal({ open, initialRegion, onClose, onConfirm }: RegionSelectModalProps) {
   return (
-    <Modal open={open} onClose={onClose} ariaLabel="지역 선택">
+    <Modal open={open} onClose={onClose} ariaLabel="지역 선택" panelClassName="max-h-none overflow-visible">
       {open ? (
         <RegionSelectForm key={initialRegion} initialRegion={initialRegion} onClose={onClose} onConfirm={onConfirm} />
       ) : null}

--- a/src/features/auth/ui/signup/SignupSelect.tsx
+++ b/src/features/auth/ui/signup/SignupSelect.tsx
@@ -25,6 +25,7 @@ export function SignupSelect({ id, label, placeholder, value, options, onChange,
   const selectId = id ?? autoId;
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
   const [open, setOpen] = useState(false);
   const [dropdownPosition, setDropdownPosition] = useState<DropdownPosition | null>(null);
 
@@ -61,7 +62,7 @@ export function SignupSelect({ id, label, placeholder, value, options, onChange,
 
     const handlePointerDown = (event: MouseEvent) => {
       const target = event.target as Node;
-      if (!rootRef.current?.contains(target)) {
+      if (!rootRef.current?.contains(target) && !dropdownRef.current?.contains(target)) {
         setOpen(false);
       }
     };
@@ -99,6 +100,7 @@ export function SignupSelect({ id, label, placeholder, value, options, onChange,
       {open && !disabled && dropdownPosition
         ? createPortal(
             <ul
+              ref={dropdownRef}
               role="listbox"
               aria-labelledby={`${selectId}-label`}
               className="fixed z-[70] max-h-52 overflow-auto rounded-xl border border-neutral-200 bg-white py-1.5 shadow-lg"

--- a/src/features/auth/ui/signup/SignupSelect.tsx
+++ b/src/features/auth/ui/signup/SignupSelect.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 interface SignupSelectProps {
   id?: string;
@@ -10,6 +11,12 @@ interface SignupSelectProps {
   disabled?: boolean;
 }
 
+interface DropdownPosition {
+  top: number;
+  left: number;
+  width: number;
+}
+
 const triggerClass =
   'flex h-12 w-full cursor-pointer items-center justify-between gap-2 rounded-xl border border-neutral-200 bg-white px-4 text-left text-sm transition-colors hover:border-neutral-300 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/15 disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-400 disabled:hover:border-neutral-200';
 
@@ -17,16 +24,44 @@ export function SignupSelect({ id, label, placeholder, value, options, onChange,
   const autoId = useId();
   const selectId = id ?? autoId;
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const [open, setOpen] = useState(false);
+  const [dropdownPosition, setDropdownPosition] = useState<DropdownPosition | null>(null);
 
   const displayLabel = value || placeholder;
   const isPlaceholder = !value;
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) return;
+
+    const updatePosition = () => {
+      if (!triggerRef.current) return;
+      const rect = triggerRef.current.getBoundingClientRect();
+
+      setDropdownPosition({
+        top: rect.bottom + 6,
+        left: rect.left,
+        width: rect.width,
+      });
+    };
+
+    updatePosition();
+
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
 
     const handlePointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target)) {
         setOpen(false);
       }
     };
@@ -47,6 +82,7 @@ export function SignupSelect({ id, label, placeholder, value, options, onChange,
       </span>
 
       <button
+        ref={triggerRef}
         type="button"
         id={selectId}
         aria-haspopup="listbox"
@@ -60,30 +96,38 @@ export function SignupSelect({ id, label, placeholder, value, options, onChange,
         <ChevronIcon open={open} />
       </button>
 
-      {open && !disabled ? (
-        <ul
-          role="listbox"
-          aria-labelledby={`${selectId}-label`}
-          className="absolute top-full z-20 mt-1.5 max-h-52 w-full overflow-auto rounded-xl border border-neutral-200 bg-white py-1.5 shadow-lg"
-        >
-          {options.map((option) => {
-            const selected = option === value;
-            return (
-              <li key={option} role="option" aria-selected={selected}>
-                <button
-                  type="button"
-                  onClick={() => handleSelect(option)}
-                  className={`w-full cursor-pointer px-3 py-2.5 text-left text-sm transition-colors hover:bg-neutral-50 ${
-                    selected ? 'bg-brand/5 font-medium text-brand' : 'text-neutral-800'
-                  }`}
-                >
-                  {option}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      ) : null}
+      {open && !disabled && dropdownPosition
+        ? createPortal(
+            <ul
+              role="listbox"
+              aria-labelledby={`${selectId}-label`}
+              className="fixed z-[70] max-h-52 overflow-auto rounded-xl border border-neutral-200 bg-white py-1.5 shadow-lg"
+              style={{
+                top: dropdownPosition.top,
+                left: dropdownPosition.left,
+                width: dropdownPosition.width,
+              }}
+            >
+              {options.map((option) => {
+                const selected = option === value;
+                return (
+                  <li key={option} role="option" aria-selected={selected}>
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(option)}
+                      className={`w-full cursor-pointer px-3 py-2.5 text-left text-sm transition-colors hover:bg-neutral-50 ${
+                        selected ? 'bg-brand/5 font-medium text-brand' : 'text-neutral-800'
+                      }`}
+                    >
+                      {option}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }

--- a/src/pages/my/MyDodoPage.tsx
+++ b/src/pages/my/MyDodoPage.tsx
@@ -1,10 +1,12 @@
+import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 
-import { useCurrentUser } from '@/features/auth';
+import { useCurrentUser, type UserProfile } from '@/features/auth';
 import { PetListContent } from '@/features/pet-list';
 import { MY_DODO_CONTENT_BY_KEY, getMyDodoMenuHref, getMyDodoMenuKeyFromSearch } from '@/pages/my/model/menu';
 import { FamilyManagementContent } from '@/pages/my/ui/FamilyManagementContent';
 import { MyDodoLayout } from '@/pages/my/ui/MyDodoLayout';
+import { MyProfileEditContent } from '@/pages/my/ui/MyProfileEditContent';
 import { MyDodoSidebarPanel } from '@/pages/my/ui/MyDodoSidebarPanel';
 import { Skeleton } from '@/shared/ui';
 
@@ -88,11 +90,19 @@ export function MyDodoPage() {
   const [searchParams] = useSearchParams();
   const activeKey = getMyDodoMenuKeyFromSearch(searchParams.get('menu'));
   const { user, profileUrl, displayName, isLoading } = useCurrentUser();
+  const [currentUser, setCurrentUser] = useState<UserProfile | null>(user);
+
+  useEffect(() => {
+    setCurrentUser(user);
+  }, [user]);
+
   const content =
     activeKey === 'pet-list' ? (
       <PetListContent />
     ) : activeKey === 'family' ? (
       <FamilyManagementContent />
+    ) : activeKey === 'profile-edit' ? (
+      <MyProfileEditContent user={currentUser} isLoading={isLoading} onProfileUpdated={setCurrentUser} />
     ) : (
       <MyDodoContent activeKey={activeKey} isLoading={isLoading} />
     );
@@ -101,7 +111,7 @@ export function MyDodoPage() {
     <MyDodoLayout
       sidebar={
         <MyDodoSidebarPanel
-          user={user}
+          user={currentUser}
           profileUrl={profileUrl}
           displayName={displayName}
           isLoading={isLoading}

--- a/src/pages/my/MyDodoPage.tsx
+++ b/src/pages/my/MyDodoPage.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 
-import { useCurrentUser, type UserProfile } from '@/features/auth';
+import { useCurrentUser } from '@/features/auth';
 import { PetListContent } from '@/features/pet-list';
 import { MY_DODO_CONTENT_BY_KEY, getMyDodoMenuHref, getMyDodoMenuKeyFromSearch } from '@/pages/my/model/menu';
 import { FamilyManagementContent } from '@/pages/my/ui/FamilyManagementContent';
@@ -90,11 +89,6 @@ export function MyDodoPage() {
   const [searchParams] = useSearchParams();
   const activeKey = getMyDodoMenuKeyFromSearch(searchParams.get('menu'));
   const { user, profileUrl, displayName, isLoading } = useCurrentUser();
-  const [currentUser, setCurrentUser] = useState<UserProfile | null>(user);
-
-  useEffect(() => {
-    setCurrentUser(user);
-  }, [user]);
 
   const content =
     activeKey === 'pet-list' ? (
@@ -102,7 +96,7 @@ export function MyDodoPage() {
     ) : activeKey === 'family' ? (
       <FamilyManagementContent />
     ) : activeKey === 'profile-edit' ? (
-      <MyProfileEditContent user={currentUser} isLoading={isLoading} onProfileUpdated={setCurrentUser} />
+      <MyProfileEditContent user={user} isLoading={isLoading} />
     ) : (
       <MyDodoContent activeKey={activeKey} isLoading={isLoading} />
     );
@@ -111,7 +105,7 @@ export function MyDodoPage() {
     <MyDodoLayout
       sidebar={
         <MyDodoSidebarPanel
-          user={currentUser}
+          user={user}
           profileUrl={profileUrl}
           displayName={displayName}
           isLoading={isLoading}

--- a/src/pages/my/ui/MyProfileEditContent.tsx
+++ b/src/pages/my/ui/MyProfileEditContent.tsx
@@ -64,9 +64,6 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
     previousImageUrlRef.current = nextProfileUrl;
     setNicknameTouched(false);
     setRegionTouched(false);
-    setSaveError('');
-    setSaveSuccess('');
-    setImageError('');
   }, [user]);
 
   const effectiveNickname = nickname.trim() || user?.nickname.trim() || '';

--- a/src/pages/my/ui/MyProfileEditContent.tsx
+++ b/src/pages/my/ui/MyProfileEditContent.tsx
@@ -202,9 +202,6 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
       <div>
         <p className="text-xs font-semibold tracking-[0.24em] text-brand">ACCOUNT</p>
         <h1 className="mt-2 text-[18px] font-medium text-neutral-950 sm:text-[20px]">회원정보 수정</h1>
-        <p className="mt-3 max-w-2xl text-sm leading-7 text-neutral-600">
-          프로필 이미지, 닉네임, 활동 지역을 수정하고 내 계정 정보를 최신 상태로 유지할 수 있어요.
-        </p>
       </div>
 
       <section className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white shadow-sm">
@@ -252,12 +249,8 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
                   최대 {MAX_IMAGE_FILE_SIZE_MB}MB
                 </span>
               </div>
-              <p className="mt-3 text-sm leading-7 text-neutral-600">
-                사진이나 버튼을 눌러 프로필 이미지를 변경할 수 있어요.
-              </p>
-              <p className="mt-1 text-sm leading-7 text-neutral-500">
-                변경 후 저장하면 마이도도와 프로필 메뉴에도 바로 반영돼요.
-              </p>
+              <p className="mt-3 text-sm leading-7 text-neutral-600">사진을 선택해 프로필 이미지를 변경할 수 있어요.</p>
+              <p className="mt-1 text-sm leading-7 text-neutral-500">변경한 이미지는 저장 후 바로 반영돼요.</p>
             </div>
           </div>
         </div>

--- a/src/pages/my/ui/MyProfileEditContent.tsx
+++ b/src/pages/my/ui/MyProfileEditContent.tsx
@@ -56,10 +56,12 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
   useEffect(() => {
     if (!user) return;
 
+    const nextProfileUrl = resolveProfileUrl(user.profileUrl);
+
     setNickname('');
     setRegion(user.region ?? '');
-    setProfileImageUrl(resolveProfileUrl(user.profileUrl));
-    previousImageUrlRef.current = resolveProfileUrl(user.profileUrl);
+    setProfileImageUrl(nextProfileUrl);
+    previousImageUrlRef.current = nextProfileUrl;
     setNicknameTouched(false);
     setRegionTouched(false);
     setSaveError('');
@@ -69,6 +71,7 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
 
   const effectiveNickname = nickname.trim() || user?.nickname.trim() || '';
   const trimmedRegion = region.trim();
+  const submittedProfileUrl = resolveProfileUrl(profileImageUrl);
   const nicknameError = validateNickname(nickname, user?.nickname ?? '');
   const regionError = validateRegion(region);
 
@@ -78,9 +81,9 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
     return (
       effectiveNickname !== user.nickname.trim() ||
       trimmedRegion !== user.region.trim() ||
-      resolveProfileUrl(profileImageUrl) !== resolveProfileUrl(user.profileUrl)
+      submittedProfileUrl !== resolveProfileUrl(user.profileUrl)
     );
-  }, [effectiveNickname, profileImageUrl, trimmedRegion, user]);
+  }, [effectiveNickname, submittedProfileUrl, trimmedRegion, user]);
 
   const canSubmit = Boolean(user) && !saving && !uploadingImage && !nicknameError && !regionError && isDirty;
 
@@ -154,17 +157,26 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
         nickname: effectiveNickname,
         region: trimmedRegion,
         hasFamily: user.hasFamily,
-        profileUrl: resolveProfileUrl(profileImageUrl),
+        profileUrl: submittedProfileUrl,
       });
+
+      const nextProfile: UserProfile = {
+        ...updatedProfile,
+        nickname: effectiveNickname,
+        region: trimmedRegion,
+        hasFamily: user.hasFamily,
+        profileUrl: submittedProfileUrl ?? updatedProfile.profileUrl,
+      };
 
       syncUserProfile({
-        profileUrl: updatedProfile.profileUrl,
-        nickname: updatedProfile.nickname,
-        region: updatedProfile.region,
-        notificationEnabled: updatedProfile.notificationEnabled,
+        profileUrl: nextProfile.profileUrl,
+        nickname: nextProfile.nickname,
+        region: nextProfile.region,
+        notificationEnabled: nextProfile.notificationEnabled,
       });
 
-      onProfileUpdated(updatedProfile);
+      previousImageUrlRef.current = resolveProfileUrl(nextProfile.profileUrl);
+      onProfileUpdated(nextProfile);
       setNickname('');
       setSaveSuccess('회원정보를 수정했어요.');
     } catch (error) {
@@ -211,6 +223,7 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
                   />
                 )}
               </div>
+
               <input
                 ref={inputRef}
                 type="file"
@@ -219,38 +232,31 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
                 disabled={uploadingImage || saving}
                 onChange={handleSelectProfileImage}
               />
+
               <button
                 type="button"
                 onClick={() => inputRef.current?.click()}
                 disabled={uploadingImage || saving}
                 className="mt-4 inline-flex min-w-32 items-center justify-center rounded-xl border border-neutral-200 bg-white px-5 py-3 text-sm font-medium text-neutral-700 transition-colors hover:border-neutral-300 hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {uploadingImage ? '업로드 중...' : '이미지 변경'}
+                {uploadingImage ? '이미지 업로드 중' : '이미지 변경'}
               </button>
-              {imageError || uploadingImage ? (
-                <FormFeedback
-                  className="mt-3 text-center"
-                  message={imageError || '이미지를 업로드하고 있어요...'}
-                  tone={imageError ? 'error' : 'neutral'}
-                />
-              ) : null}
+
+              {imageError ? <FormFeedback className="mt-3 text-center" message={imageError} tone="error" /> : null}
             </div>
 
             <div className="flex h-full flex-col justify-center rounded-[20px] border border-neutral-200 bg-neutral-50/70 px-5 py-5">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="text-[17px] font-medium text-neutral-950">프로필 이미지</span>
                 <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-neutral-500 ring-1 ring-neutral-200">
-                  JPG / PNG
-                </span>
-                <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-neutral-500 ring-1 ring-neutral-200">
                   최대 {MAX_IMAGE_FILE_SIZE_MB}MB
                 </span>
               </div>
               <p className="mt-3 text-sm leading-7 text-neutral-600">
-                사진이나 하단 버튼을 눌러 프로필 이미지를 변경할 수 있어요.
+                사진이나 버튼을 눌러 프로필 이미지를 변경할 수 있어요.
               </p>
               <p className="mt-1 text-sm leading-7 text-neutral-500">
-                업로드한 이미지는 저장 후 마이도도 화면에 바로 반영됩니다.
+                변경 후 저장하면 마이도도와 프로필 메뉴에도 바로 반영돼요.
               </p>
             </div>
           </div>

--- a/src/pages/my/ui/MyProfileEditContent.tsx
+++ b/src/pages/my/ui/MyProfileEditContent.tsx
@@ -75,8 +75,8 @@ export function MyProfileEditContent({ user, isLoading = false }: MyProfileEditC
     if (!user) return false;
 
     return (
-      effectiveNickname !== user.nickname.trim() ||
-      trimmedRegion !== user.region.trim() ||
+      effectiveNickname !== (user.nickname ?? '').trim() ||
+      trimmedRegion !== (user.region ?? '').trim() ||
       submittedProfileUrl !== resolveProfileUrl(user.profileUrl)
     );
   }, [effectiveNickname, submittedProfileUrl, trimmedRegion, user]);

--- a/src/pages/my/ui/MyProfileEditContent.tsx
+++ b/src/pages/my/ui/MyProfileEditContent.tsx
@@ -1,0 +1,387 @@
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+
+import { PROFILE_UPDATE_STATUS_MESSAGES, getApiErrorMessage, updateMyProfile, type UserProfile } from '@/features/auth';
+import { RegionSelectModal } from '@/features/auth/ui/signup/RegionSelectModal';
+import { FormFeedback, PrimaryButton, SubButton } from '@/features/auth/ui/signup/SignupStepLayout';
+import { syncUserProfile } from '@/shared/lib/auth/token';
+import { Skeleton } from '@/shared/ui';
+
+interface MyProfileEditContentProps {
+  user: UserProfile | null;
+  isLoading?: boolean;
+  onProfileUpdated: (profile: UserProfile) => void;
+}
+
+const inputClass =
+  'h-12 w-full rounded-xl border border-neutral-200 bg-white px-4 text-sm text-neutral-800 outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/15';
+const readonlyFieldClass =
+  'flex h-12 w-full items-center rounded-xl border border-neutral-300 bg-neutral-100 px-4 text-sm text-neutral-500';
+
+function validateNickname(value: string): string {
+  const trimmed = value.trim();
+
+  if (!trimmed) return '닉네임을 입력해주세요.';
+  if (trimmed.length < 2 || trimmed.length > 10) return '닉네임은 2자 이상 10자 이하로 입력해주세요.';
+
+  return '';
+}
+
+function validateRegion(value: string): string {
+  const trimmed = value.trim();
+
+  if (!trimmed) return '지역을 선택해주세요.';
+  if (trimmed.length > 50) return '지역은 50자 이하로 입력해주세요.';
+
+  return '';
+}
+
+export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated }: MyProfileEditContentProps) {
+  const [nickname, setNickname] = useState('');
+  const [region, setRegion] = useState('');
+  const [hasFamily, setHasFamily] = useState(false);
+  const [regionModalOpen, setRegionModalOpen] = useState(false);
+  const [nicknameTouched, setNicknameTouched] = useState(false);
+  const [regionTouched, setRegionTouched] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [saveSuccess, setSaveSuccess] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+
+    setNickname(user.nickname ?? '');
+    setRegion(user.region ?? '');
+    setHasFamily(user.hasFamily);
+    setNicknameTouched(false);
+    setRegionTouched(false);
+    setSaveError('');
+    setSaveSuccess('');
+  }, [user]);
+
+  const trimmedNickname = nickname.trim();
+  const trimmedRegion = region.trim();
+  const nicknameError = validateNickname(nickname);
+  const regionError = validateRegion(region);
+
+  const isDirty = useMemo(() => {
+    if (!user) return false;
+
+    return (
+      trimmedNickname !== user.nickname.trim() || trimmedRegion !== user.region.trim() || hasFamily !== user.hasFamily
+    );
+  }, [hasFamily, trimmedNickname, trimmedRegion, user]);
+
+  const canSubmit = Boolean(user) && !saving && !nicknameError && !regionError && isDirty;
+
+  const handleNicknameChange = (value: string) => {
+    setNickname(value);
+    setNicknameTouched(true);
+    setSaveError('');
+    setSaveSuccess('');
+  };
+
+  const handleRegionChange = (value: string) => {
+    setRegion(value);
+    setRegionTouched(true);
+    setSaveError('');
+    setSaveSuccess('');
+  };
+
+  const handleFamilyChange = (next: boolean) => {
+    setHasFamily(next);
+    setSaveError('');
+    setSaveSuccess('');
+  };
+
+  const handleSubmit = async () => {
+    if (!user) return;
+
+    setNicknameTouched(true);
+    setRegionTouched(true);
+
+    if (nicknameError || regionError || !isDirty) {
+      return;
+    }
+
+    setSaving(true);
+    setSaveError('');
+    setSaveSuccess('');
+
+    try {
+      const updatedProfile = await updateMyProfile({
+        nickname: trimmedNickname,
+        region: trimmedRegion,
+        hasFamily,
+      });
+
+      syncUserProfile({
+        profileUrl: updatedProfile.profileUrl,
+        nickname: updatedProfile.nickname,
+        region: updatedProfile.region,
+        notificationEnabled: updatedProfile.notificationEnabled,
+      });
+
+      onProfileUpdated(updatedProfile);
+      setSaveSuccess('회원정보를 수정했어요.');
+    } catch (error) {
+      console.error('[my-profile] update failed', error);
+      setSaveError(
+        getApiErrorMessage(
+          error,
+          '회원정보 수정에 실패했어요. 잠시 후 다시 시도해주세요.',
+          PROFILE_UPDATE_STATUS_MESSAGES,
+        ),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return <MyProfileEditSkeleton />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-xs font-semibold tracking-[0.24em] text-brand">ACCOUNT</p>
+        <h1 className="mt-2 text-[18px] font-medium text-neutral-950 sm:text-[20px]">회원정보 수정</h1>
+        <p className="mt-3 text-sm leading-6 text-neutral-600">
+          현재 로그인한 내 정보를 확인하고 닉네임, 활동 지역, 가족 여부를 수정할 수 있어요.
+        </p>
+      </div>
+
+      <section className="overflow-hidden rounded-[20px] border border-neutral-200 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.04)]">
+        <div className="border-b border-neutral-100 bg-linear-to-r from-brand/[0.04] via-white to-white px-6 py-5 sm:px-8">
+          <h2 className="text-[18px] font-medium text-neutral-950">내 프로필 정보</h2>
+          <p className="mt-2 text-sm leading-6 text-neutral-600">
+            수정한 정보는 저장 직후 마이도도 화면에 바로 반영돼요.
+          </p>
+        </div>
+
+        <div className="space-y-6 px-6 py-6 sm:px-8 sm:py-7">
+          <div className="grid gap-5 md:grid-cols-2">
+            <FieldBlock label="이메일">
+              <div className={readonlyFieldClass} aria-readonly>
+                {user?.email ?? '-'}
+              </div>
+            </FieldBlock>
+
+            <FieldBlock label="이름">
+              <div className={readonlyFieldClass} aria-readonly>
+                {user?.name ?? '-'}
+              </div>
+            </FieldBlock>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+            <FieldBlock label="닉네임" required>
+              <input
+                className={inputClass}
+                value={nickname}
+                maxLength={10}
+                onChange={(event) => handleNicknameChange(event.target.value)}
+                placeholder="닉네임을 입력해주세요"
+              />
+              <FormFeedback
+                message={nicknameTouched ? nicknameError : '2자 이상 10자 이하로 입력해주세요.'}
+                tone={nicknameTouched && nicknameError ? 'error' : 'neutral'}
+              />
+            </FieldBlock>
+
+            <div className="hidden md:block">
+              <label className="mb-1.5 block text-sm font-medium text-transparent">보조 액션</label>
+              <SubButton onClick={() => setNickname((user?.nickname ?? '').trim())} disabled={!user || saving}>
+                원래대로
+              </SubButton>
+            </div>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+            <FieldBlock label="활동 지역" required>
+              <button
+                type="button"
+                onClick={() => setRegionModalOpen(true)}
+                className={`${readonlyFieldClass} cursor-pointer justify-between text-left ${
+                  region ? 'text-neutral-800' : 'text-neutral-400'
+                }`}
+              >
+                <span className="truncate">{region || '지역을 선택해주세요'}</span>
+                <span className="ml-4 text-xs font-medium text-neutral-400">선택</span>
+              </button>
+              <FormFeedback
+                message={regionTouched ? regionError : '현재 활동 중인 지역을 선택해주세요.'}
+                tone={regionTouched && regionError ? 'error' : 'neutral'}
+              />
+            </FieldBlock>
+
+            <div className="hidden md:block">
+              <label className="mb-1.5 block text-sm font-medium text-transparent">지역 선택</label>
+              <SubButton onClick={() => setRegionModalOpen(true)} disabled={saving}>
+                지역 선택
+              </SubButton>
+            </div>
+          </div>
+
+          <FieldBlock label="가족 여부">
+            <div className="grid gap-3 md:grid-cols-2">
+              <FamilyChoiceCard
+                title="가족이 있어요"
+                description="가족 계정과 함께 반려동물 정보를 관리하고 있어요."
+                selected={hasFamily}
+                disabled={saving}
+                onClick={() => handleFamilyChange(true)}
+              />
+              <FamilyChoiceCard
+                title="혼자 사용 중이에요"
+                description="현재는 가족 연동 없이 내 계정만 사용하고 있어요."
+                selected={!hasFamily}
+                disabled={saving}
+                onClick={() => handleFamilyChange(false)}
+              />
+            </div>
+          </FieldBlock>
+
+          <div className="rounded-[16px] border border-neutral-200 bg-neutral-50 px-4 py-4">
+            <p className="text-sm font-medium text-neutral-800">저장 전 확인</p>
+            <ul className="mt-2 space-y-1 text-sm leading-6 text-neutral-600">
+              <li>닉네임은 2자 이상 10자 이하로 입력해주세요.</li>
+              <li>지역은 최대 50자까지 저장할 수 있어요.</li>
+              <li>중복 닉네임 등 서버 오류가 발생하면 바로 안내해드려요.</li>
+            </ul>
+          </div>
+
+          <div className="space-y-2">
+            <FormFeedback
+              message={saveError || saveSuccess}
+              tone={saveError ? 'error' : saveSuccess ? 'success' : 'neutral'}
+            />
+            <PrimaryButton onClick={handleSubmit} disabled={!canSubmit} loading={saving}>
+              변경사항 저장
+            </PrimaryButton>
+          </div>
+        </div>
+      </section>
+
+      <RegionSelectModal
+        open={regionModalOpen}
+        initialRegion={region}
+        onClose={() => setRegionModalOpen(false)}
+        onConfirm={handleRegionChange}
+      />
+    </div>
+  );
+}
+
+function FieldBlock({ label, required = false, children }: { label: string; required?: boolean; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium text-neutral-800">
+        {label}
+        {required ? <span className="ml-1 text-brand">*</span> : null}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function FamilyChoiceCard({
+  title,
+  description,
+  selected,
+  disabled = false,
+  onClick,
+}: {
+  title: string;
+  description: string;
+  selected: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={[
+        'rounded-[18px] border bg-white px-5 py-5 text-left shadow-sm transition-all disabled:cursor-not-allowed disabled:opacity-60',
+        selected ? 'border-brand ring-1 ring-brand' : 'border-neutral-200 hover:border-brand/50',
+      ].join(' ')}
+    >
+      <div className="flex items-start gap-4">
+        <span
+          className={[
+            'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] text-white transition-colors',
+            selected ? 'bg-brand' : 'bg-neutral-300',
+          ].join(' ')}
+          aria-hidden
+        >
+          {selected ? '✓' : ''}
+        </span>
+
+        <div>
+          <p className="text-base font-semibold text-neutral-900">{title}</p>
+          <p className="mt-2 text-sm leading-6 text-neutral-500">{description}</p>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function MyProfileEditSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <Skeleton className="h-3 w-16 rounded-md" />
+        <Skeleton className="mt-4 h-8 w-40 rounded-lg" />
+        <Skeleton className="mt-4 h-4 w-80 rounded-md" />
+      </div>
+
+      <div className="overflow-hidden rounded-[20px] border border-neutral-200 bg-white shadow-sm">
+        <div className="border-b border-neutral-100 px-6 py-5 sm:px-8">
+          <Skeleton className="h-6 w-36 rounded-lg" />
+          <Skeleton className="mt-3 h-4 w-72 rounded-md" />
+        </div>
+
+        <div className="space-y-6 px-6 py-6 sm:px-8 sm:py-7">
+          <div className="grid gap-5 md:grid-cols-2">
+            <FieldSkeleton />
+            <FieldSkeleton />
+          </div>
+          <FieldSkeleton />
+          <FieldSkeleton />
+          <div className="grid gap-3 md:grid-cols-2">
+            <ChoiceSkeleton />
+            <ChoiceSkeleton />
+          </div>
+          <Skeleton className="h-12 w-full rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FieldSkeleton() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-4 w-20 rounded-md" />
+      <Skeleton className="h-12 w-full rounded-xl" />
+      <Skeleton className="h-4 w-52 rounded-md" />
+    </div>
+  );
+}
+
+function ChoiceSkeleton() {
+  return (
+    <div className="rounded-[18px] border border-neutral-200 bg-white px-5 py-5 shadow-sm">
+      <div className="flex items-start gap-4">
+        <Skeleton className="mt-0.5 h-5 w-5 rounded-full" />
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-5 w-28 rounded-md" />
+          <Skeleton className="h-4 w-full rounded-md" />
+          <Skeleton className="h-4 w-10/12 rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/my/ui/MyProfileEditContent.tsx
+++ b/src/pages/my/ui/MyProfileEditContent.tsx
@@ -12,7 +12,6 @@ import { Skeleton } from '@/shared/ui';
 interface MyProfileEditContentProps {
   user: UserProfile | null;
   isLoading?: boolean;
-  onProfileUpdated: (profile: UserProfile) => void;
 }
 
 function validateNickname(value: string, fallback: string): string {
@@ -38,7 +37,7 @@ function resolveProfileUrl(url: string | null | undefined): string | null {
   return trimmed ? trimmed : null;
 }
 
-export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated }: MyProfileEditContentProps) {
+export function MyProfileEditContent({ user, isLoading = false }: MyProfileEditContentProps) {
   const [nickname, setNickname] = useState('');
   const [region, setRegion] = useState('');
   const [regionModalOpen, setRegionModalOpen] = useState(false);
@@ -173,7 +172,6 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
       });
 
       previousImageUrlRef.current = resolveProfileUrl(nextProfile.profileUrl);
-      onProfileUpdated(nextProfile);
       setNickname('');
       setSaveSuccess('회원정보를 수정했어요.');
     } catch (error) {

--- a/src/pages/my/ui/MyProfileEditContent.tsx
+++ b/src/pages/my/ui/MyProfileEditContent.tsx
@@ -1,9 +1,12 @@
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { type ChangeEvent, type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
+import profileDefaultIllustration from '@/features/auth/assets/profile-default.svg';
 import { PROFILE_UPDATE_STATUS_MESSAGES, getApiErrorMessage, updateMyProfile, type UserProfile } from '@/features/auth';
 import { RegionSelectModal } from '@/features/auth/ui/signup/RegionSelectModal';
 import { FormFeedback } from '@/features/auth/ui/signup/SignupStepLayout';
+import { uploadImage } from '@/shared/api/files';
 import { syncUserProfile } from '@/shared/lib/auth/token';
+import { IMAGE_UPLOAD_ACCEPT, MAX_IMAGE_FILE_SIZE_MB, validateImageFile } from '@/shared/lib/files/imageUploadPolicy';
 import { Skeleton } from '@/shared/ui';
 
 interface MyProfileEditContentProps {
@@ -12,8 +15,8 @@ interface MyProfileEditContentProps {
   onProfileUpdated: (profile: UserProfile) => void;
 }
 
-function validateNickname(value: string): string {
-  const trimmed = value.trim();
+function validateNickname(value: string, fallback: string): string {
+  const trimmed = value.trim() || fallback.trim();
 
   if (!trimmed) return '닉네임을 입력해주세요.';
   if (trimmed.length < 2 || trimmed.length > 10) return '닉네임은 2자 이상 10자 이하로 입력해주세요.';
@@ -30,6 +33,11 @@ function validateRegion(value: string): string {
   return '';
 }
 
+function resolveProfileUrl(url: string | null | undefined): string | null {
+  const trimmed = url?.trim();
+  return trimmed ? trimmed : null;
+}
+
 export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated }: MyProfileEditContentProps) {
   const [nickname, setNickname] = useState('');
   const [region, setRegion] = useState('');
@@ -39,30 +47,42 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
   const [saveError, setSaveError] = useState('');
   const [saveSuccess, setSaveSuccess] = useState('');
   const [saving, setSaving] = useState(false);
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+  const [uploadingImage, setUploadingImage] = useState(false);
+  const [imageError, setImageError] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const previousImageUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!user) return;
 
-    setNickname(user.nickname ?? '');
+    setNickname('');
     setRegion(user.region ?? '');
+    setProfileImageUrl(resolveProfileUrl(user.profileUrl));
+    previousImageUrlRef.current = resolveProfileUrl(user.profileUrl);
     setNicknameTouched(false);
     setRegionTouched(false);
     setSaveError('');
     setSaveSuccess('');
+    setImageError('');
   }, [user]);
 
-  const trimmedNickname = nickname.trim();
+  const effectiveNickname = nickname.trim() || user?.nickname.trim() || '';
   const trimmedRegion = region.trim();
-  const nicknameError = validateNickname(nickname);
+  const nicknameError = validateNickname(nickname, user?.nickname ?? '');
   const regionError = validateRegion(region);
 
   const isDirty = useMemo(() => {
     if (!user) return false;
 
-    return trimmedNickname !== user.nickname.trim() || trimmedRegion !== user.region.trim();
-  }, [trimmedNickname, trimmedRegion, user]);
+    return (
+      effectiveNickname !== user.nickname.trim() ||
+      trimmedRegion !== user.region.trim() ||
+      resolveProfileUrl(profileImageUrl) !== resolveProfileUrl(user.profileUrl)
+    );
+  }, [effectiveNickname, profileImageUrl, trimmedRegion, user]);
 
-  const canSubmit = Boolean(user) && !saving && !nicknameError && !regionError && isDirty;
+  const canSubmit = Boolean(user) && !saving && !uploadingImage && !nicknameError && !regionError && isDirty;
 
   const handleNicknameChange = (value: string) => {
     setNickname(value);
@@ -78,11 +98,41 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
     setSaveSuccess('');
   };
 
-  const handleResetNickname = () => {
-    setNickname(user?.nickname ?? '');
-    setNicknameTouched(false);
+  const handleSelectProfileImage = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+
+    if (!file || uploadingImage) return;
+
+    try {
+      validateImageFile(file);
+    } catch (error) {
+      setImageError(error instanceof Error ? error.message : '이미지 파일을 다시 확인해주세요.');
+      return;
+    }
+
+    setUploadingImage(true);
+    setImageError('');
     setSaveError('');
     setSaveSuccess('');
+
+    const previewUrl = URL.createObjectURL(file);
+    setProfileImageUrl(previewUrl);
+
+    try {
+      const uploadedUrl = await uploadImage(file);
+      URL.revokeObjectURL(previewUrl);
+      const resolvedUrl = resolveProfileUrl(uploadedUrl);
+      setProfileImageUrl(resolvedUrl);
+      previousImageUrlRef.current = resolvedUrl;
+    } catch (error) {
+      URL.revokeObjectURL(previewUrl);
+      setProfileImageUrl(previousImageUrlRef.current);
+      setImageError('프로필 이미지 업로드에 실패했어요. 다시 시도해주세요.');
+      console.error('[my-profile] image upload failed', error);
+    } finally {
+      setUploadingImage(false);
+    }
   };
 
   const handleSubmit = async () => {
@@ -101,9 +151,10 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
 
     try {
       const updatedProfile = await updateMyProfile({
-        nickname: trimmedNickname,
+        nickname: effectiveNickname,
         region: trimmedRegion,
         hasFamily: user.hasFamily,
+        profileUrl: resolveProfileUrl(profileImageUrl),
       });
 
       syncUserProfile({
@@ -114,6 +165,7 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
       });
 
       onProfileUpdated(updatedProfile);
+      setNickname('');
       setSaveSuccess('회원정보를 수정했어요.');
     } catch (error) {
       console.error('[my-profile] update failed', error);
@@ -139,7 +191,7 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
         <p className="text-xs font-semibold tracking-[0.24em] text-brand">ACCOUNT</p>
         <h1 className="mt-2 text-[18px] font-medium text-neutral-950 sm:text-[20px]">회원정보 수정</h1>
         <p className="mt-3 max-w-2xl text-sm leading-7 text-neutral-600">
-          닉네임과 활동 지역을 수정해 내 프로필 정보를 최신 상태로 유지할 수 있어요.
+          프로필 이미지, 닉네임, 활동 지역을 수정하고 내 계정 정보를 최신 상태로 유지할 수 있어요.
         </p>
       </div>
 
@@ -148,39 +200,67 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
           <div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)] lg:items-stretch">
             <div className="flex flex-col items-center rounded-[20px] border border-neutral-200 bg-white px-5 py-5">
               <div className="flex h-32 w-32 items-center justify-center overflow-hidden rounded-full border border-neutral-200 bg-neutral-100">
-                {user?.profileUrl ? (
-                  <img src={user.profileUrl} alt="" className="h-full w-full object-cover" />
+                {profileImageUrl ? (
+                  <img src={profileImageUrl} alt="" className="h-full w-full object-cover" />
                 ) : (
-                  <div className="h-full w-full bg-neutral-100" />
+                  <img
+                    src={profileDefaultIllustration}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    draggable={false}
+                  />
                 )}
               </div>
-              <div className="mt-4 w-full rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-center text-sm text-neutral-500">
-                프로필 이미지는 현재 수정 대상이 아니에요.
-              </div>
+              <input
+                ref={inputRef}
+                type="file"
+                accept={IMAGE_UPLOAD_ACCEPT}
+                className="sr-only"
+                disabled={uploadingImage || saving}
+                onChange={handleSelectProfileImage}
+              />
+              <button
+                type="button"
+                onClick={() => inputRef.current?.click()}
+                disabled={uploadingImage || saving}
+                className="mt-4 inline-flex min-w-32 items-center justify-center rounded-xl border border-neutral-200 bg-white px-5 py-3 text-sm font-medium text-neutral-700 transition-colors hover:border-neutral-300 hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {uploadingImage ? '업로드 중...' : '이미지 변경'}
+              </button>
+              {imageError || uploadingImage ? (
+                <FormFeedback
+                  className="mt-3 text-center"
+                  message={imageError || '이미지를 업로드하고 있어요...'}
+                  tone={imageError ? 'error' : 'neutral'}
+                />
+              ) : null}
             </div>
 
             <div className="flex h-full flex-col justify-center rounded-[20px] border border-neutral-200 bg-neutral-50/70 px-5 py-5">
               <div className="flex flex-wrap items-center gap-2">
-                <span className="text-[17px] font-medium text-neutral-950">프로필 정보</span>
+                <span className="text-[17px] font-medium text-neutral-950">프로필 이미지</span>
                 <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-neutral-500 ring-1 ring-neutral-200">
-                  닉네임
+                  JPG / PNG
                 </span>
                 <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-neutral-500 ring-1 ring-neutral-200">
-                  활동 지역
+                  최대 {MAX_IMAGE_FILE_SIZE_MB}MB
                 </span>
               </div>
               <p className="mt-3 text-sm leading-7 text-neutral-600">
-                현재 계정의 기본 프로필 정보를 차분하게 정리하고 바로 저장할 수 있어요.
+                사진이나 하단 버튼을 눌러 프로필 이미지를 변경할 수 있어요.
               </p>
               <p className="mt-1 text-sm leading-7 text-neutral-500">
-                저장한 정보는 마이도도 화면과 프로필 카드에 즉시 반영됩니다.
+                업로드한 이미지는 저장 후 마이도도 화면에 바로 반영됩니다.
               </p>
             </div>
           </div>
         </div>
       </section>
 
-      <FormCard title="기본 정보" description="이메일, 이름, 닉네임, 활동 지역을 확인하고 필요한 값만 수정해 주세요.">
+      <FormCard
+        title="기본 정보"
+        description="이메일과 이름은 조회만 가능하고, 닉네임과 활동 지역은 이 화면에서 수정할 수 있어요."
+      >
         <div className="grid gap-5 lg:grid-cols-2">
           <ReadonlyField label="이메일" value={user?.email ?? '-'} />
           <ReadonlyField label="이름" value={user?.name ?? '-'} />
@@ -191,7 +271,7 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
               value={nickname}
               maxLength={10}
               onChange={(event) => handleNicknameChange(event.target.value)}
-              placeholder="닉네임을 입력해주세요"
+              placeholder={user?.nickname ?? '닉네임을 입력해주세요'}
               className={[
                 'mt-2 h-12 w-full rounded-xl border bg-white px-4 text-sm text-neutral-900 outline-none transition-colors placeholder:text-neutral-400',
                 nicknameTouched && nicknameError
@@ -199,21 +279,10 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
                   : 'border-neutral-200 focus:border-brand',
               ].join(' ')}
             />
-            <div className="mt-2 flex items-center justify-between gap-3">
-              <FormFeedback
-                className="min-h-0 flex-1"
-                message={nicknameTouched ? nicknameError : '2자 이상 10자 이하로 입력해주세요.'}
-                tone={nicknameTouched && nicknameError ? 'error' : 'neutral'}
-              />
-              <button
-                type="button"
-                onClick={handleResetNickname}
-                disabled={!user || saving}
-                className="shrink-0 rounded-lg border border-neutral-200 bg-white px-3 py-2 text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                원래대로
-              </button>
-            </div>
+            <FormFeedback
+              message={nicknameTouched ? nicknameError : '비워두면 현재 닉네임을 그대로 유지해요.'}
+              tone={nicknameTouched && nicknameError ? 'error' : 'neutral'}
+            />
           </FieldBlock>
 
           <FieldBlock label="활동 지역" required>

--- a/src/pages/my/ui/MyProfileEditContent.tsx
+++ b/src/pages/my/ui/MyProfileEditContent.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { PROFILE_UPDATE_STATUS_MESSAGES, getApiErrorMessage, updateMyProfile, type UserProfile } from '@/features/auth';
 import { RegionSelectModal } from '@/features/auth/ui/signup/RegionSelectModal';
-import { FormFeedback, PrimaryButton, SubButton } from '@/features/auth/ui/signup/SignupStepLayout';
+import { FormFeedback } from '@/features/auth/ui/signup/SignupStepLayout';
 import { syncUserProfile } from '@/shared/lib/auth/token';
 import { Skeleton } from '@/shared/ui';
 
@@ -11,11 +11,6 @@ interface MyProfileEditContentProps {
   isLoading?: boolean;
   onProfileUpdated: (profile: UserProfile) => void;
 }
-
-const inputClass =
-  'h-12 w-full rounded-xl border border-neutral-200 bg-white px-4 text-sm text-neutral-800 outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/15';
-const readonlyFieldClass =
-  'flex h-12 w-full items-center rounded-xl border border-neutral-300 bg-neutral-100 px-4 text-sm text-neutral-500';
 
 function validateNickname(value: string): string {
   const trimmed = value.trim();
@@ -29,8 +24,8 @@ function validateNickname(value: string): string {
 function validateRegion(value: string): string {
   const trimmed = value.trim();
 
-  if (!trimmed) return '지역을 선택해주세요.';
-  if (trimmed.length > 50) return '지역은 50자 이하로 입력해주세요.';
+  if (!trimmed) return '활동 지역을 선택해주세요.';
+  if (trimmed.length > 50) return '활동 지역은 50자 이하로 입력해주세요.';
 
   return '';
 }
@@ -38,7 +33,6 @@ function validateRegion(value: string): string {
 export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated }: MyProfileEditContentProps) {
   const [nickname, setNickname] = useState('');
   const [region, setRegion] = useState('');
-  const [hasFamily, setHasFamily] = useState(false);
   const [regionModalOpen, setRegionModalOpen] = useState(false);
   const [nicknameTouched, setNicknameTouched] = useState(false);
   const [regionTouched, setRegionTouched] = useState(false);
@@ -51,7 +45,6 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
 
     setNickname(user.nickname ?? '');
     setRegion(user.region ?? '');
-    setHasFamily(user.hasFamily);
     setNicknameTouched(false);
     setRegionTouched(false);
     setSaveError('');
@@ -66,10 +59,8 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
   const isDirty = useMemo(() => {
     if (!user) return false;
 
-    return (
-      trimmedNickname !== user.nickname.trim() || trimmedRegion !== user.region.trim() || hasFamily !== user.hasFamily
-    );
-  }, [hasFamily, trimmedNickname, trimmedRegion, user]);
+    return trimmedNickname !== user.nickname.trim() || trimmedRegion !== user.region.trim();
+  }, [trimmedNickname, trimmedRegion, user]);
 
   const canSubmit = Boolean(user) && !saving && !nicknameError && !regionError && isDirty;
 
@@ -87,8 +78,9 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
     setSaveSuccess('');
   };
 
-  const handleFamilyChange = (next: boolean) => {
-    setHasFamily(next);
+  const handleResetNickname = () => {
+    setNickname(user?.nickname ?? '');
+    setNicknameTouched(false);
     setSaveError('');
     setSaveSuccess('');
   };
@@ -111,7 +103,7 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
       const updatedProfile = await updateMyProfile({
         nickname: trimmedNickname,
         region: trimmedRegion,
-        hasFamily,
+        hasFamily: user.hasFamily,
       });
 
       syncUserProfile({
@@ -146,122 +138,124 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
       <div>
         <p className="text-xs font-semibold tracking-[0.24em] text-brand">ACCOUNT</p>
         <h1 className="mt-2 text-[18px] font-medium text-neutral-950 sm:text-[20px]">회원정보 수정</h1>
-        <p className="mt-3 text-sm leading-6 text-neutral-600">
-          현재 로그인한 내 정보를 확인하고 닉네임, 활동 지역, 가족 여부를 수정할 수 있어요.
+        <p className="mt-3 max-w-2xl text-sm leading-7 text-neutral-600">
+          닉네임과 활동 지역을 수정해 내 프로필 정보를 최신 상태로 유지할 수 있어요.
         </p>
       </div>
 
-      <section className="overflow-hidden rounded-[20px] border border-neutral-200 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.04)]">
-        <div className="border-b border-neutral-100 bg-linear-to-r from-brand/[0.04] via-white to-white px-6 py-5 sm:px-8">
-          <h2 className="text-[18px] font-medium text-neutral-950">내 프로필 정보</h2>
-          <p className="mt-2 text-sm leading-6 text-neutral-600">
-            수정한 정보는 저장 직후 마이도도 화면에 바로 반영돼요.
-          </p>
-        </div>
-
-        <div className="space-y-6 px-6 py-6 sm:px-8 sm:py-7">
-          <div className="grid gap-5 md:grid-cols-2">
-            <FieldBlock label="이메일">
-              <div className={readonlyFieldClass} aria-readonly>
-                {user?.email ?? '-'}
+      <section className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white shadow-sm">
+        <div className="flex flex-col gap-5 px-5 py-5 sm:px-6 sm:py-6">
+          <div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)] lg:items-stretch">
+            <div className="flex flex-col items-center rounded-[20px] border border-neutral-200 bg-white px-5 py-5">
+              <div className="flex h-32 w-32 items-center justify-center overflow-hidden rounded-full border border-neutral-200 bg-neutral-100">
+                {user?.profileUrl ? (
+                  <img src={user.profileUrl} alt="" className="h-full w-full object-cover" />
+                ) : (
+                  <div className="h-full w-full bg-neutral-100" />
+                )}
               </div>
-            </FieldBlock>
-
-            <FieldBlock label="이름">
-              <div className={readonlyFieldClass} aria-readonly>
-                {user?.name ?? '-'}
+              <div className="mt-4 w-full rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-center text-sm text-neutral-500">
+                프로필 이미지는 현재 수정 대상이 아니에요.
               </div>
-            </FieldBlock>
-          </div>
-
-          <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
-            <FieldBlock label="닉네임" required>
-              <input
-                className={inputClass}
-                value={nickname}
-                maxLength={10}
-                onChange={(event) => handleNicknameChange(event.target.value)}
-                placeholder="닉네임을 입력해주세요"
-              />
-              <FormFeedback
-                message={nicknameTouched ? nicknameError : '2자 이상 10자 이하로 입력해주세요.'}
-                tone={nicknameTouched && nicknameError ? 'error' : 'neutral'}
-              />
-            </FieldBlock>
-
-            <div className="hidden md:block">
-              <label className="mb-1.5 block text-sm font-medium text-transparent">보조 액션</label>
-              <SubButton onClick={() => setNickname((user?.nickname ?? '').trim())} disabled={!user || saving}>
-                원래대로
-              </SubButton>
             </div>
-          </div>
 
-          <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
-            <FieldBlock label="활동 지역" required>
-              <button
-                type="button"
-                onClick={() => setRegionModalOpen(true)}
-                className={`${readonlyFieldClass} cursor-pointer justify-between text-left ${
-                  region ? 'text-neutral-800' : 'text-neutral-400'
-                }`}
-              >
-                <span className="truncate">{region || '지역을 선택해주세요'}</span>
-                <span className="ml-4 text-xs font-medium text-neutral-400">선택</span>
-              </button>
-              <FormFeedback
-                message={regionTouched ? regionError : '현재 활동 중인 지역을 선택해주세요.'}
-                tone={regionTouched && regionError ? 'error' : 'neutral'}
-              />
-            </FieldBlock>
-
-            <div className="hidden md:block">
-              <label className="mb-1.5 block text-sm font-medium text-transparent">지역 선택</label>
-              <SubButton onClick={() => setRegionModalOpen(true)} disabled={saving}>
-                지역 선택
-              </SubButton>
+            <div className="flex h-full flex-col justify-center rounded-[20px] border border-neutral-200 bg-neutral-50/70 px-5 py-5">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[17px] font-medium text-neutral-950">프로필 정보</span>
+                <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-neutral-500 ring-1 ring-neutral-200">
+                  닉네임
+                </span>
+                <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-neutral-500 ring-1 ring-neutral-200">
+                  활동 지역
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-7 text-neutral-600">
+                현재 계정의 기본 프로필 정보를 차분하게 정리하고 바로 저장할 수 있어요.
+              </p>
+              <p className="mt-1 text-sm leading-7 text-neutral-500">
+                저장한 정보는 마이도도 화면과 프로필 카드에 즉시 반영됩니다.
+              </p>
             </div>
-          </div>
-
-          <FieldBlock label="가족 여부">
-            <div className="grid gap-3 md:grid-cols-2">
-              <FamilyChoiceCard
-                title="가족이 있어요"
-                description="가족 계정과 함께 반려동물 정보를 관리하고 있어요."
-                selected={hasFamily}
-                disabled={saving}
-                onClick={() => handleFamilyChange(true)}
-              />
-              <FamilyChoiceCard
-                title="혼자 사용 중이에요"
-                description="현재는 가족 연동 없이 내 계정만 사용하고 있어요."
-                selected={!hasFamily}
-                disabled={saving}
-                onClick={() => handleFamilyChange(false)}
-              />
-            </div>
-          </FieldBlock>
-
-          <div className="rounded-[16px] border border-neutral-200 bg-neutral-50 px-4 py-4">
-            <p className="text-sm font-medium text-neutral-800">저장 전 확인</p>
-            <ul className="mt-2 space-y-1 text-sm leading-6 text-neutral-600">
-              <li>닉네임은 2자 이상 10자 이하로 입력해주세요.</li>
-              <li>지역은 최대 50자까지 저장할 수 있어요.</li>
-              <li>중복 닉네임 등 서버 오류가 발생하면 바로 안내해드려요.</li>
-            </ul>
-          </div>
-
-          <div className="space-y-2">
-            <FormFeedback
-              message={saveError || saveSuccess}
-              tone={saveError ? 'error' : saveSuccess ? 'success' : 'neutral'}
-            />
-            <PrimaryButton onClick={handleSubmit} disabled={!canSubmit} loading={saving}>
-              변경사항 저장
-            </PrimaryButton>
           </div>
         </div>
       </section>
+
+      <FormCard title="기본 정보" description="이메일, 이름, 닉네임, 활동 지역을 확인하고 필요한 값만 수정해 주세요.">
+        <div className="grid gap-5 lg:grid-cols-2">
+          <ReadonlyField label="이메일" value={user?.email ?? '-'} />
+          <ReadonlyField label="이름" value={user?.name ?? '-'} />
+
+          <FieldBlock label="닉네임" required>
+            <input
+              type="text"
+              value={nickname}
+              maxLength={10}
+              onChange={(event) => handleNicknameChange(event.target.value)}
+              placeholder="닉네임을 입력해주세요"
+              className={[
+                'mt-2 h-12 w-full rounded-xl border bg-white px-4 text-sm text-neutral-900 outline-none transition-colors placeholder:text-neutral-400',
+                nicknameTouched && nicknameError
+                  ? 'border-red-300 focus:border-red-400'
+                  : 'border-neutral-200 focus:border-brand',
+              ].join(' ')}
+            />
+            <div className="mt-2 flex items-center justify-between gap-3">
+              <FormFeedback
+                className="min-h-0 flex-1"
+                message={nicknameTouched ? nicknameError : '2자 이상 10자 이하로 입력해주세요.'}
+                tone={nicknameTouched && nicknameError ? 'error' : 'neutral'}
+              />
+              <button
+                type="button"
+                onClick={handleResetNickname}
+                disabled={!user || saving}
+                className="shrink-0 rounded-lg border border-neutral-200 bg-white px-3 py-2 text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                원래대로
+              </button>
+            </div>
+          </FieldBlock>
+
+          <FieldBlock label="활동 지역" required>
+            <button
+              type="button"
+              onClick={() => setRegionModalOpen(true)}
+              className={[
+                'mt-2 flex h-12 w-full items-center rounded-xl border bg-white px-4 text-left text-sm outline-none transition-colors',
+                regionTouched && regionError
+                  ? 'border-red-300 focus:border-red-400'
+                  : 'border-neutral-200 hover:border-brand/60',
+                region ? 'text-neutral-900' : 'text-neutral-400',
+              ].join(' ')}
+            >
+              <span className="truncate">{region || '활동 지역을 선택해주세요'}</span>
+            </button>
+            <FormFeedback
+              message={regionTouched ? regionError : '클릭해서 활동 지역을 선택해주세요.'}
+              tone={regionTouched && regionError ? 'error' : 'neutral'}
+            />
+          </FieldBlock>
+        </div>
+      </FormCard>
+
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-sm text-neutral-500">
+          <span className="font-semibold text-brand">*</span> 표시된 항목은 필수 입력값입니다.
+        </p>
+        {saveError ? <p className="max-w-md text-right text-sm text-red-500">{saveError}</p> : null}
+      </div>
+
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        {saveSuccess ? <p className="self-center text-sm text-green-600">{saveSuccess}</p> : null}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="inline-flex min-w-32 items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-medium text-brand-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {saving ? '수정 중...' : '변경사항 저장'}
+        </button>
+      </div>
 
       <RegionSelectModal
         open={regionModalOpen}
@@ -273,58 +267,39 @@ export function MyProfileEditContent({ user, isLoading = false, onProfileUpdated
   );
 }
 
-function FieldBlock({ label, required = false, children }: { label: string; required?: boolean; children: ReactNode }) {
+function FormCard({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
   return (
-    <div className="flex flex-col gap-1.5">
-      <label className="text-sm font-medium text-neutral-800">
-        {label}
-        {required ? <span className="ml-1 text-brand">*</span> : null}
-      </label>
-      {children}
-    </div>
+    <section className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white shadow-sm">
+      <div className="border-b border-neutral-100 px-6 py-5 sm:px-8">
+        <h2 className="text-[18px] font-medium text-neutral-950">{title}</h2>
+        {description ? <p className="mt-1 text-sm text-neutral-500">{description}</p> : null}
+      </div>
+
+      <div className="px-6 py-6 sm:px-8">{children}</div>
+    </section>
   );
 }
 
-function FamilyChoiceCard({
-  title,
-  description,
-  selected,
-  disabled = false,
-  onClick,
-}: {
-  title: string;
-  description: string;
-  selected: boolean;
-  disabled?: boolean;
-  onClick: () => void;
-}) {
+function FieldBlock({ label, required = false, children }: { label: string; required?: boolean; children: ReactNode }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={[
-        'rounded-[18px] border bg-white px-5 py-5 text-left shadow-sm transition-all disabled:cursor-not-allowed disabled:opacity-60',
-        selected ? 'border-brand ring-1 ring-brand' : 'border-neutral-200 hover:border-brand/50',
-      ].join(' ')}
-    >
-      <div className="flex items-start gap-4">
-        <span
-          className={[
-            'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] text-white transition-colors',
-            selected ? 'bg-brand' : 'bg-neutral-300',
-          ].join(' ')}
-          aria-hidden
-        >
-          {selected ? '✓' : ''}
-        </span>
+    <label className="block">
+      <span className="text-sm font-medium text-neutral-800">
+        {label}
+        {required ? <span className="ml-1 text-brand">*</span> : null}
+      </span>
+      {children}
+    </label>
+  );
+}
 
-        <div>
-          <p className="text-base font-semibold text-neutral-900">{title}</p>
-          <p className="mt-2 text-sm leading-6 text-neutral-500">{description}</p>
-        </div>
+function ReadonlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="block">
+      <span className="text-sm font-medium text-neutral-800">{label}</span>
+      <div className="mt-2 flex h-12 w-full items-center rounded-xl border border-neutral-200 bg-neutral-50 px-4 text-sm text-neutral-700">
+        {value}
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -337,24 +312,25 @@ function MyProfileEditSkeleton() {
         <Skeleton className="mt-4 h-4 w-80 rounded-md" />
       </div>
 
-      <div className="overflow-hidden rounded-[20px] border border-neutral-200 bg-white shadow-sm">
+      <div className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white shadow-sm">
+        <div className="px-5 py-5 sm:px-6 sm:py-6">
+          <div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)]">
+            <Skeleton className="h-56 rounded-[20px]" />
+            <Skeleton className="h-56 rounded-[20px]" />
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-[24px] border border-neutral-200 bg-white shadow-sm">
         <div className="border-b border-neutral-100 px-6 py-5 sm:px-8">
-          <Skeleton className="h-6 w-36 rounded-lg" />
+          <Skeleton className="h-6 w-24 rounded-lg" />
           <Skeleton className="mt-3 h-4 w-72 rounded-md" />
         </div>
-
-        <div className="space-y-6 px-6 py-6 sm:px-8 sm:py-7">
-          <div className="grid gap-5 md:grid-cols-2">
-            <FieldSkeleton />
-            <FieldSkeleton />
-          </div>
+        <div className="grid gap-5 px-6 py-6 sm:px-8 lg:grid-cols-2">
           <FieldSkeleton />
           <FieldSkeleton />
-          <div className="grid gap-3 md:grid-cols-2">
-            <ChoiceSkeleton />
-            <ChoiceSkeleton />
-          </div>
-          <Skeleton className="h-12 w-full rounded-xl" />
+          <FieldSkeleton />
+          <FieldSkeleton />
         </div>
       </div>
     </div>
@@ -366,22 +342,7 @@ function FieldSkeleton() {
     <div className="space-y-2">
       <Skeleton className="h-4 w-20 rounded-md" />
       <Skeleton className="h-12 w-full rounded-xl" />
-      <Skeleton className="h-4 w-52 rounded-md" />
-    </div>
-  );
-}
-
-function ChoiceSkeleton() {
-  return (
-    <div className="rounded-[18px] border border-neutral-200 bg-white px-5 py-5 shadow-sm">
-      <div className="flex items-start gap-4">
-        <Skeleton className="mt-0.5 h-5 w-5 rounded-full" />
-        <div className="flex-1 space-y-3">
-          <Skeleton className="h-5 w-28 rounded-md" />
-          <Skeleton className="h-4 w-full rounded-md" />
-          <Skeleton className="h-4 w-10/12 rounded-md" />
-        </div>
-      </div>
+      <Skeleton className="h-4 w-48 rounded-md" />
     </div>
   );
 }

--- a/src/shared/lib/auth/token.ts
+++ b/src/shared/lib/auth/token.ts
@@ -4,6 +4,7 @@ const LEGACY_REFRESH_TOKEN_KEY = 'refreshToken';
 const REFRESH_TOKEN_KEY = 'dodo.refreshToken';
 const PROFILE_URL_KEY = 'profileUrl';
 const NICKNAME_KEY = 'nickname';
+const REGION_KEY = 'region';
 const NOTIFICATION_ENABLED_KEY = 'notificationEnabled';
 const ACCESS_TOKEN_EXPIRES_AT_KEY = 'accessTokenExpiresAt';
 const ACCESS_TOKEN_TTL_MS_KEY = 'accessTokenTtlMs';
@@ -85,6 +86,7 @@ export function subscribeAuthState(listener: () => void): () => void {
       event.key === LEGACY_REFRESH_TOKEN_KEY ||
       event.key === PROFILE_URL_KEY ||
       event.key === NICKNAME_KEY ||
+      event.key === REGION_KEY ||
       event.key === NOTIFICATION_ENABLED_KEY ||
       event.key === ACCESS_TOKEN_EXPIRES_AT_KEY ||
       event.key === ACCESS_TOKEN_TTL_MS_KEY
@@ -156,6 +158,10 @@ export function getNickname(): string | null {
   return localStorage.getItem(NICKNAME_KEY);
 }
 
+export function getRegion(): string | null {
+  return localStorage.getItem(REGION_KEY);
+}
+
 export function setNotificationEnabled(enabled: boolean): void {
   localStorage.setItem(NOTIFICATION_ENABLED_KEY, enabled ? 'true' : 'false');
   notifyAuthStateChanged();
@@ -171,6 +177,7 @@ export function getNotificationEnabled(): boolean | null {
 export function syncUserProfile(profile: {
   profileUrl?: string;
   nickname?: string;
+  region?: string;
   notificationEnabled?: boolean;
 }): void {
   const profileUrl = profile.profileUrl?.trim();
@@ -181,6 +188,11 @@ export function syncUserProfile(profile: {
   const nickname = profile.nickname?.trim();
   if (nickname) {
     localStorage.setItem(NICKNAME_KEY, nickname);
+  }
+
+  const region = profile.region?.trim();
+  if (region) {
+    localStorage.setItem(REGION_KEY, region);
   }
 
   if (profile.notificationEnabled !== undefined) {
@@ -200,6 +212,7 @@ export function clearTokens(): void {
   sessionStorage.removeItem(REFRESH_TOKEN_KEY);
   localStorage.removeItem(PROFILE_URL_KEY);
   localStorage.removeItem(NICKNAME_KEY);
+  localStorage.removeItem(REGION_KEY);
   localStorage.removeItem(NOTIFICATION_ENABLED_KEY);
   localStorage.removeItem(ACCESS_TOKEN_EXPIRES_AT_KEY);
   localStorage.removeItem(ACCESS_TOKEN_TTL_MS_KEY);

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -12,9 +12,10 @@ interface ModalProps {
   children: ReactNode;
   /** 스크린리더용 대화상자 라벨 */
   ariaLabel?: string;
+  panelClassName?: string;
 }
 
-export function Modal({ open, onClose, children, ariaLabel }: ModalProps) {
+export function Modal({ open, onClose, children, ariaLabel, panelClassName = '' }: ModalProps) {
   const { isRendered, isVisible, handleTransitionEnd } = usePresence(open);
 
   useEffect(() => {
@@ -57,7 +58,7 @@ export function Modal({ open, onClose, children, ariaLabel }: ModalProps) {
       <div className="flex min-h-full items-center justify-center">
         <div
           onTransitionEnd={handleTransitionEnd}
-          className={`relative w-full max-w-sm max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl transition-all duration-500 ease-out ${
+          className={`relative w-full max-w-sm max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl transition-all duration-500 ease-out ${panelClassName} ${
             isVisible ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-3 scale-95 opacity-0'
           }`}
         >


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 마이도도 회원정보 수정 화면 UI를 구현
- 현재 로그인한 사용자의 프로필 정보를 조회해 초기값으로 노출하도록 연결
- 닉네임, 활동 지역 수정 기능을 `PATCH /users/me`와 연동
- 프로필 이미지 변경 UI를 추가하고, 이미지 업로드 후 저장 플로우를 연결
- 저장 성공 시 닉네임/지역/프로필 이미지가 마이도도 화면과 프로필 표시 영역에 즉시 반영되도록 처리
- 지역 선택 모달에서 드롭다운이 잘리던 문제를 수정


<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #50 

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

<img width="1862" height="1434" alt="image" src="https://github.com/user-attachments/assets/b2c1bb1f-a53c-4029-a64f-612be732eccb" />


<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

아래 사항 확인해 주시면 감사하겠습니다 :D
- 회원정보 수정 화면 진입 및 초기 사용자 정보 노출
- 닉네임/활동 지역 수정 가능
- 저장 후 화면 내 프로필 정보 즉시 반영
- 프로필 이미지 업로드 UI 동작
- 지역 선택 모달 드롭다운 정상 노출
