### PR TITLE
✨ Feat: 커뮤니티 게시물 반응 기능 구현

### DIFF
--- a/src/features/community/api/reactions.ts
+++ b/src/features/community/api/reactions.ts
@@ -1,0 +1,21 @@
+import { apiClient } from '@/shared/api/axios';
+
+import type { BoardReactionResponse, CreateBoardReactionRequest, UpdateBoardReactionRequest } from '../model/types';
+
+export async function createBoardReaction(payload: CreateBoardReactionRequest): Promise<BoardReactionResponse> {
+  const response = await apiClient.post<BoardReactionResponse>('/reactions/board', payload);
+  return response.data;
+}
+
+export async function updateBoardReaction(
+  boardId: number,
+  payload: UpdateBoardReactionRequest,
+): Promise<BoardReactionResponse> {
+  const response = await apiClient.patch<BoardReactionResponse>(`/reactions/board/${boardId}`, payload);
+  return response.data;
+}
+
+export async function deleteBoardReaction(boardId: number): Promise<BoardReactionResponse> {
+  const response = await apiClient.delete<BoardReactionResponse>(`/reactions/board/${boardId}`);
+  return response.data;
+}

--- a/src/features/community/index.ts
+++ b/src/features/community/index.ts
@@ -9,16 +9,19 @@ export {
   updateBoard,
 } from './api/boards';
 export { createComment, deleteComment, getCommentList, getMyCommentList, updateComment } from './api/comments';
+export { deleteBoardReaction, createBoardReaction, updateBoardReaction } from './api/reactions';
 export {
   BOARD_DETAIL_STATUS_MESSAGES,
   BOARD_DRAFT_STATUS_MESSAGES,
   BOARD_LIST_STATUS_MESSAGES,
   BOARD_MUTATION_STATUS_MESSAGES,
+  BOARD_REACTION_STATUS_MESSAGES,
   COMMENT_LIST_STATUS_MESSAGES,
   COMMENT_MUTATION_STATUS_MESSAGES,
   COMMUNITY_DRAFT_SESSION_KEY,
   MY_ACTIVITY_STATUS_MESSAGES,
 } from './lib/constants';
+export { getBoardReactionType, normalizeReactionType } from './lib/reactions';
 export {
   clearStoredBoardDraftSessionKey,
   getStoredBoardDraftSessionKey,
@@ -28,6 +31,7 @@ export { INITIAL_BOARD_EDITOR_FORM_STATE, validateBoardEditorForm } from './lib/
 export { useBoardDetail } from './model/useBoardDetail';
 export { useBoardEditorForm } from './model/useBoardEditorForm';
 export { useBoardList } from './model/useBoardList';
+export { useBoardReaction } from './model/useBoardReaction';
 export { useCommentList } from './model/useCommentList';
 export { useCreateBoard } from './model/useCreateBoard';
 export { useCreateComment } from './model/useCreateComment';
@@ -52,22 +56,26 @@ export type {
   BoardListItem,
   BoardListResponse,
   BoardPayload,
+  BoardReactionResponse,
   CommentListResponse,
   CommentPageInfo,
   CreateCommentRequest,
   CreateCommentResponse,
   CreateBoardRequest,
   CreateBoardResponse,
+  CreateBoardReactionRequest,
   DeleteCommentResponse,
   DeleteBoardResponse,
   MyBoardListResponse,
   MyCommentListItem,
   MyCommentListResponse,
+  ReactionType,
   TempSavedBoardResponse,
   TempSaveBoardRequest,
   TempSaveBoardResponse,
   UpdateCommentRequest,
   UpdateCommentResponse,
+  UpdateBoardReactionRequest,
   UpdateBoardRequest,
   UpdateBoardResponse,
 } from './model/types';

--- a/src/features/community/index.ts
+++ b/src/features/community/index.ts
@@ -23,8 +23,11 @@ export {
 } from './lib/constants';
 export { getBoardReactionType, getReactionCountDelta, normalizeReactionType } from './lib/reactions';
 export {
+  clearStoredBoardReactionType,
   clearStoredBoardDraftSessionKey,
+  getStoredBoardReactionType,
   getStoredBoardDraftSessionKey,
+  setStoredBoardReactionType,
   setStoredBoardDraftSessionKey,
 } from './lib/storage';
 export { INITIAL_BOARD_EDITOR_FORM_STATE, validateBoardEditorForm } from './lib/validation';

--- a/src/features/community/index.ts
+++ b/src/features/community/index.ts
@@ -21,7 +21,7 @@ export {
   COMMUNITY_DRAFT_SESSION_KEY,
   MY_ACTIVITY_STATUS_MESSAGES,
 } from './lib/constants';
-export { getBoardReactionType, normalizeReactionType } from './lib/reactions';
+export { getBoardReactionType, getReactionCountDelta, normalizeReactionType } from './lib/reactions';
 export {
   clearStoredBoardDraftSessionKey,
   getStoredBoardDraftSessionKey,

--- a/src/features/community/lib/constants.ts
+++ b/src/features/community/lib/constants.ts
@@ -1,7 +1,7 @@
 export const COMMUNITY_DRAFT_SESSION_KEY = 'community-board-draft-session-key';
 
 export const BOARD_LIST_STATUS_MESSAGES: Partial<Record<number, string>> = {
-  400: '잘못된 요청이에요.',
+  400: '게시글 목록 요청이 올바르지 않아요.',
   401: '로그인이 필요해요. 다시 로그인해주세요.',
   500: '서버 오류가 발생했어요. 잠시 후 다시 시도해주세요.',
 };
@@ -13,8 +13,17 @@ export const BOARD_MUTATION_STATUS_MESSAGES: Partial<Record<number, string>> = {
   500: '서버 오류가 발생했어요. 잠시 후 다시 시도해주세요.',
 };
 
+export const BOARD_REACTION_STATUS_MESSAGES: Partial<Record<number, string>> = {
+  400: '반응 요청이 올바르지 않아요. 다시 시도해주세요.',
+  401: '로그인이 필요한 기능이에요. 다시 로그인해주세요.',
+  403: '이 게시물에 반응할 권한이 없어요.',
+  404: '게시물을 찾을 수 없거나 남긴 반응이 없어요.',
+  409: '이미 같은 반응을 남긴 게시물이에요.',
+  500: '서버 오류가 발생했어요. 잠시 후 다시 시도해주세요.',
+};
+
 export const BOARD_DETAIL_STATUS_MESSAGES: Partial<Record<number, string>> = {
-  400: '잘못된 게시글 요청이에요.',
+  400: '게시글 요청이 올바르지 않아요.',
   401: '로그인이 필요해요. 다시 로그인해주세요.',
   403: '게시글을 조회할 권한이 없어요.',
   404: '게시글을 찾을 수 없어요.',

--- a/src/features/community/lib/reactions.ts
+++ b/src/features/community/lib/reactions.ts
@@ -1,0 +1,68 @@
+import type { BoardDetailResponse, BoardListItem, ReactionType } from '../model/types';
+
+const REACTION_TYPES: ReactionType[] = ['LIKE', 'DISLIKE'];
+
+function clampCount(value: number) {
+  return Math.max(0, value);
+}
+
+export function normalizeReactionType(value: unknown): ReactionType | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.toUpperCase();
+  return REACTION_TYPES.includes(normalized as ReactionType) ? (normalized as ReactionType) : null;
+}
+
+export function getBoardReactionType(board: Partial<BoardDetailResponse> | null | undefined): ReactionType | null {
+  if (!board) {
+    return null;
+  }
+
+  return (
+    normalizeReactionType(board.reactionType) ??
+    normalizeReactionType(board.myReactionType) ??
+    normalizeReactionType(board.currentUserReactionType) ??
+    normalizeReactionType(board.userReactionType)
+  );
+}
+
+export function getReactionCountDelta(previousReaction: ReactionType | null, nextReaction: ReactionType | null) {
+  const likeDelta = (nextReaction === 'LIKE' ? 1 : 0) - (previousReaction === 'LIKE' ? 1 : 0);
+  const dislikeDelta = (nextReaction === 'DISLIKE' ? 1 : 0) - (previousReaction === 'DISLIKE' ? 1 : 0);
+
+  return { likeDelta, dislikeDelta };
+}
+
+export function applyReactionToBoardDetail(
+  board: BoardDetailResponse,
+  previousReaction: ReactionType | null,
+  nextReaction: ReactionType | null,
+): BoardDetailResponse {
+  const { likeDelta, dislikeDelta } = getReactionCountDelta(previousReaction, nextReaction);
+
+  return {
+    ...board,
+    likeCount: clampCount((board.likeCount ?? 0) + likeDelta),
+    dislikeCount: clampCount((board.dislikeCount ?? 0) + dislikeDelta),
+    reactionType: nextReaction,
+    myReactionType: nextReaction,
+    currentUserReactionType: nextReaction,
+    userReactionType: nextReaction,
+  };
+}
+
+export function applyReactionToBoardListItem(
+  board: BoardListItem,
+  previousReaction: ReactionType | null,
+  nextReaction: ReactionType | null,
+): BoardListItem {
+  const { likeDelta, dislikeDelta } = getReactionCountDelta(previousReaction, nextReaction);
+
+  return {
+    ...board,
+    likeCount: clampCount(board.likeCount + likeDelta),
+    dislikeCount: clampCount(board.dislikeCount + dislikeDelta),
+  };
+}

--- a/src/features/community/lib/storage.ts
+++ b/src/features/community/lib/storage.ts
@@ -1,4 +1,7 @@
 import { COMMUNITY_DRAFT_SESSION_KEY } from './constants';
+import type { ReactionType } from '../model/types';
+
+const COMMUNITY_BOARD_REACTION_KEY_PREFIX = 'community-board-reaction';
 
 export function getStoredBoardDraftSessionKey(): string | null {
   if (typeof window === 'undefined') {
@@ -23,4 +26,33 @@ export function clearStoredBoardDraftSessionKey() {
   }
 
   window.localStorage.removeItem(COMMUNITY_DRAFT_SESSION_KEY);
+}
+
+function getBoardReactionStorageKey(boardId: number) {
+  return `${COMMUNITY_BOARD_REACTION_KEY_PREFIX}:${boardId}`;
+}
+
+export function getStoredBoardReactionType(boardId: number): ReactionType | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const value = window.localStorage.getItem(getBoardReactionStorageKey(boardId));
+  return value === 'LIKE' || value === 'DISLIKE' ? value : null;
+}
+
+export function setStoredBoardReactionType(boardId: number, reactionType: ReactionType) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(getBoardReactionStorageKey(boardId), reactionType);
+}
+
+export function clearStoredBoardReactionType(boardId: number) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.removeItem(getBoardReactionStorageKey(boardId));
 }

--- a/src/features/community/model/types.ts
+++ b/src/features/community/model/types.ts
@@ -61,8 +61,8 @@ export interface BoardDetailResponse {
   imageFileUrls: string[];
   profileUrl: string | null;
   nickname: string;
-  likeCount?: number;
-  dislikeCount?: number;
+  likeCount: number;
+  dislikeCount: number;
   commentCount?: number;
   viewCount: number;
   boardCreatedAt: string;

--- a/src/features/community/model/types.ts
+++ b/src/features/community/model/types.ts
@@ -12,6 +12,8 @@ export interface BoardListItem {
   modifiedAt: string;
 }
 
+export type ReactionType = 'LIKE' | 'DISLIKE';
+
 export interface BoardListResponse {
   message: string;
   boards: BoardListItem[];
@@ -60,10 +62,28 @@ export interface BoardDetailResponse {
   profileUrl: string | null;
   nickname: string;
   likeCount?: number;
+  dislikeCount?: number;
   commentCount?: number;
   viewCount: number;
   boardCreatedAt: string;
   modifiedAt: string;
+  reactionType?: ReactionType | null;
+  myReactionType?: ReactionType | null;
+  currentUserReactionType?: ReactionType | null;
+  userReactionType?: ReactionType | null;
+}
+
+export interface CreateBoardReactionRequest {
+  boardId: number;
+  reactionType: ReactionType;
+}
+
+export interface UpdateBoardReactionRequest {
+  reactionType: ReactionType;
+}
+
+export interface BoardReactionResponse {
+  message: string;
 }
 
 export type UpdateBoardRequest = BoardPayload;

--- a/src/features/community/model/useBoardReaction.ts
+++ b/src/features/community/model/useBoardReaction.ts
@@ -1,0 +1,114 @@
+import { useMutation, useQueryClient, type InfiniteData } from '@tanstack/react-query';
+
+import { createBoardReaction, deleteBoardReaction, updateBoardReaction } from '../api/reactions';
+import { applyReactionToBoardDetail, applyReactionToBoardListItem } from '../lib/reactions';
+import type { BoardDetailResponse, BoardListResponse, MyBoardListResponse, ReactionType } from './types';
+import { queryKeys } from '@/shared/lib/react-query/queryKey';
+
+interface BoardReactionVariables {
+  boardId: number;
+  nextReactionType: ReactionType;
+  currentReactionType: ReactionType | null;
+}
+
+interface BoardReactionContext {
+  previousDetail?: BoardDetailResponse;
+  previousListInfinite?: InfiniteData<BoardListResponse, number>;
+  previousMineQueries: Array<readonly [readonly unknown[], MyBoardListResponse | undefined]>;
+}
+
+function updateBoardListResponse(
+  data: BoardListResponse,
+  boardId: number,
+  previousReaction: ReactionType | null,
+  nextReaction: ReactionType | null,
+) {
+  return {
+    ...data,
+    boards: data.boards.map((board) =>
+      board.boardId === boardId ? applyReactionToBoardListItem(board, previousReaction, nextReaction) : board,
+    ),
+  };
+}
+
+export function useBoardReaction() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ boardId, nextReactionType, currentReactionType }: BoardReactionVariables) => {
+      if (currentReactionType === null) {
+        return createBoardReaction({ boardId, reactionType: nextReactionType });
+      }
+
+      if (currentReactionType === nextReactionType) {
+        return deleteBoardReaction(boardId);
+      }
+
+      return updateBoardReaction(boardId, { reactionType: nextReactionType });
+    },
+    onMutate: async ({ boardId, nextReactionType, currentReactionType }): Promise<BoardReactionContext> => {
+      const optimisticReactionType = currentReactionType === nextReactionType ? null : nextReactionType;
+
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: queryKeys.boards.detail(boardId) }),
+        queryClient.cancelQueries({ queryKey: queryKeys.boards.listInfinite() }),
+        queryClient.cancelQueries({ queryKey: ['boards', 'mine'] }),
+      ]);
+
+      const previousDetail = queryClient.getQueryData<BoardDetailResponse>(queryKeys.boards.detail(boardId));
+      const previousListInfinite = queryClient.getQueryData<InfiniteData<BoardListResponse, number>>(
+        queryKeys.boards.listInfinite(),
+      );
+      const previousMineQueries = queryClient.getQueriesData<MyBoardListResponse>({ queryKey: ['boards', 'mine'] });
+
+      queryClient.setQueryData<BoardDetailResponse>(queryKeys.boards.detail(boardId), (current) =>
+        current ? applyReactionToBoardDetail(current, currentReactionType, optimisticReactionType) : current,
+      );
+
+      queryClient.setQueryData<InfiniteData<BoardListResponse, number>>(queryKeys.boards.listInfinite(), (current) =>
+        current
+          ? {
+              ...current,
+              pages: current.pages.map((page) =>
+                updateBoardListResponse(page, boardId, currentReactionType, optimisticReactionType),
+              ),
+            }
+          : current,
+      );
+
+      queryClient.setQueriesData<MyBoardListResponse>({ queryKey: ['boards', 'mine'] }, (current) =>
+        current ? updateBoardListResponse(current, boardId, currentReactionType, optimisticReactionType) : current,
+      );
+
+      return {
+        previousDetail,
+        previousListInfinite,
+        previousMineQueries,
+      };
+    },
+    onError: (_error, variables, context) => {
+      if (!context) {
+        return;
+      }
+
+      if (context.previousDetail) {
+        queryClient.setQueryData(queryKeys.boards.detail(variables.boardId), context.previousDetail);
+      }
+
+      if (context.previousListInfinite) {
+        queryClient.setQueryData(queryKeys.boards.listInfinite(), context.previousListInfinite);
+      }
+
+      context.previousMineQueries.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+    },
+    onSettled: async (_data, _error, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.boards.detail(variables.boardId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.boards.listInfinite() }),
+        queryClient.invalidateQueries({ queryKey: ['boards', 'mine'] }),
+      ]);
+    },
+  });
+}

--- a/src/features/community/model/useBoardReaction.ts
+++ b/src/features/community/model/useBoardReaction.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient, type InfiniteData } from '@tanstack/react-
 
 import { createBoardReaction, deleteBoardReaction, updateBoardReaction } from '../api/reactions';
 import { applyReactionToBoardDetail, applyReactionToBoardListItem } from '../lib/reactions';
-import type { BoardDetailResponse, BoardListResponse, MyBoardListResponse, ReactionType } from './types';
+import type { BoardDetailResponse, BoardListItem, BoardListResponse, MyBoardListResponse, ReactionType } from './types';
 import { queryKeys } from '@/shared/lib/react-query/queryKey';
 
 interface BoardReactionVariables {
@@ -17,12 +17,12 @@ interface BoardReactionContext {
   previousMineQueries: Array<readonly [readonly unknown[], MyBoardListResponse | undefined]>;
 }
 
-function updateBoardListResponse(
-  data: BoardListResponse,
+function updateBoardListResponse<T extends { boards: BoardListItem[] }>(
+  data: T,
   boardId: number,
   previousReaction: ReactionType | null,
   nextReaction: ReactionType | null,
-) {
+): T {
   return {
     ...data,
     boards: data.boards.map((board) =>
@@ -52,14 +52,16 @@ export function useBoardReaction() {
       await Promise.all([
         queryClient.cancelQueries({ queryKey: queryKeys.boards.detail(boardId) }),
         queryClient.cancelQueries({ queryKey: queryKeys.boards.listInfinite() }),
-        queryClient.cancelQueries({ queryKey: ['boards', 'mine'] }),
+        queryClient.cancelQueries({ queryKey: queryKeys.boards.mineAll() }),
       ]);
 
       const previousDetail = queryClient.getQueryData<BoardDetailResponse>(queryKeys.boards.detail(boardId));
       const previousListInfinite = queryClient.getQueryData<InfiniteData<BoardListResponse, number>>(
         queryKeys.boards.listInfinite(),
       );
-      const previousMineQueries = queryClient.getQueriesData<MyBoardListResponse>({ queryKey: ['boards', 'mine'] });
+      const previousMineQueries = queryClient.getQueriesData<MyBoardListResponse>({
+        queryKey: queryKeys.boards.mineAll(),
+      });
 
       queryClient.setQueryData<BoardDetailResponse>(queryKeys.boards.detail(boardId), (current) =>
         current ? applyReactionToBoardDetail(current, currentReactionType, optimisticReactionType) : current,
@@ -76,7 +78,7 @@ export function useBoardReaction() {
           : current,
       );
 
-      queryClient.setQueriesData<MyBoardListResponse>({ queryKey: ['boards', 'mine'] }, (current) =>
+      queryClient.setQueriesData<MyBoardListResponse>({ queryKey: queryKeys.boards.mineAll() }, (current) =>
         current ? updateBoardListResponse(current, boardId, currentReactionType, optimisticReactionType) : current,
       );
 
@@ -107,7 +109,7 @@ export function useBoardReaction() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.boards.detail(variables.boardId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.boards.listInfinite() }),
-        queryClient.invalidateQueries({ queryKey: ['boards', 'mine'] }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.boards.mineAll() }),
       ]);
     },
   });

--- a/src/features/community/ui/BoardDetailContent.tsx
+++ b/src/features/community/ui/BoardDetailContent.tsx
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import type { BoardComment, BoardDetailResponse, CommentPageInfo } from '../model/types';
+import type { BoardComment, BoardDetailResponse, CommentPageInfo, ReactionType } from '../model/types';
 
 interface BoardDetailContentProps {
   board: BoardDetailResponse;
@@ -14,7 +14,11 @@ interface BoardDetailContentProps {
   isCreatingComment: boolean;
   isUpdatingComment: boolean;
   isDeletingComment: boolean;
+  currentReactionType: ReactionType | null;
+  isReacting: boolean;
+  reactionErrorMessage?: string;
   onDelete: () => void;
+  onReact: (reactionType: ReactionType) => Promise<void>;
   onRetryComments: () => void;
   onCreateComment: (payload: { commentContent: string; parentCommentId?: number | null }) => Promise<void>;
   onUpdateComment: (payload: { commentId: number; commentContent: string }) => Promise<void>;
@@ -145,11 +149,15 @@ export function BoardDetailContent({
   isUpdatingComment,
   isDeletingComment,
   onDelete,
+  onReact,
   onRetryComments,
   onCreateComment,
   onUpdateComment,
   onDeleteComment,
   onChangeCommentPage,
+  currentReactionType,
+  isReacting,
+  reactionErrorMessage,
 }: BoardDetailContentProps) {
   const [draftComment, setDraftComment] = useState('');
   const [replyTargetId, setReplyTargetId] = useState<number | null>(null);
@@ -162,6 +170,7 @@ export function BoardDetailContent({
   const [deleteError, setDeleteError] = useState<{ commentId: number; message: string } | null>(null);
 
   const likeCount = board.likeCount ?? 0;
+  const dislikeCount = board.dislikeCount ?? 0;
   const commentCount = board.commentCount ?? pageInfo?.totalElements ?? comments.length;
   const authorName = board.nickname.trim() || DETAIL_COPY.authorFallback;
   const imageUrls = board.imageFileUrls.filter((imageUrl) => imageUrl.trim().length > 0);
@@ -318,10 +327,32 @@ export function BoardDetailContent({
                 {board.boardContent}
               </p>
 
-              <div className="flex items-center justify-end gap-5 border-t border-neutral-200 pt-5">
-                <SocialStat kind="like" value={likeCount} />
-                <SocialStat kind="comment" value={commentCount} />
+              <div className="flex flex-col gap-4 border-t border-neutral-200 pt-5 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap items-center gap-3">
+                  <ReactionButton
+                    reactionType="LIKE"
+                    label="좋아요"
+                    count={likeCount}
+                    active={currentReactionType === 'LIKE'}
+                    disabled={isReacting}
+                    onClick={() => void onReact('LIKE')}
+                  />
+                  <ReactionButton
+                    reactionType="DISLIKE"
+                    label="싫어요"
+                    count={dislikeCount}
+                    active={currentReactionType === 'DISLIKE'}
+                    disabled={isReacting}
+                    onClick={() => void onReact('DISLIKE')}
+                  />
+                </div>
+
+                <div className="flex items-center gap-5">
+                  <SocialStat kind="comment" value={commentCount} />
+                </div>
               </div>
+
+              {reactionErrorMessage ? <p className="text-sm text-red-500">{reactionErrorMessage}</p> : null}
             </div>
           </div>
         </div>
@@ -573,6 +604,40 @@ function SocialStat({ kind, value }: { kind: 'like' | 'comment'; value: number }
   );
 }
 
+interface ReactionButtonProps {
+  reactionType: ReactionType;
+  label: string;
+  count: number;
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+function ReactionButton({ reactionType, label, count, active, disabled, onClick }: ReactionButtonProps) {
+  const activeClass =
+    reactionType === 'LIKE'
+      ? 'border-[#ef3c32]/30 bg-[#ef3c32]/8 text-[#d93025]'
+      : 'border-[#4b5563]/30 bg-neutral-100 text-neutral-700';
+  const idleClass = 'border-neutral-200 bg-white text-neutral-500 hover:border-neutral-300 hover:text-neutral-700';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={[
+        'inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+        active ? activeClass : idleClass,
+      ].join(' ')}
+      aria-pressed={active}
+    >
+      {reactionType === 'LIKE' ? <ThumbsUpIcon className="h-5 w-5" /> : <ThumbsDownIcon className="h-5 w-5" />}
+      <span>{label}</span>
+      <span>{count}</span>
+    </button>
+  );
+}
+
 interface CommentRowProps {
   comment: BoardComment;
   currentUserId?: string | null;
@@ -785,6 +850,18 @@ function ThumbsUpIcon({ className }: { className?: string }) {
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden className={className}>
       <path
         d="M9.5 10.5 12.5 4a2 2 0 0 1 3.8.8V9h2.2a2 2 0 0 1 2 2.4l-1 5A2 2 0 0 1 17.5 18H9.5m0-7.5V18m0-7.5H6a1.5 1.5 0 0 0-1.5 1.5v4A1.5 1.5 0 0 0 6 17.5h3.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ThumbsDownIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden className={className}>
+      <path
+        d="M14.5 13.5 11.5 20a2 2 0 0 1-3.8-.8V15H5.5a2 2 0 0 1-2-2.4l1-5A2 2 0 0 1 6.5 6h8m0 7.5V6m0 7.5H18A1.5 1.5 0 0 0 19.5 12v-4A1.5 1.5 0 0 0 18 6.5h-3.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/src/features/community/ui/BoardDetailContent.tsx
+++ b/src/features/community/ui/BoardDetailContent.tsx
@@ -14,6 +14,8 @@ interface BoardDetailContentProps {
   isCreatingComment: boolean;
   isUpdatingComment: boolean;
   isDeletingComment: boolean;
+  displayedLikeCount: number;
+  displayedDislikeCount: number;
   currentReactionType: ReactionType | null;
   isReacting: boolean;
   reactionErrorMessage?: string;
@@ -148,6 +150,11 @@ export function BoardDetailContent({
   isCreatingComment,
   isUpdatingComment,
   isDeletingComment,
+  displayedLikeCount,
+  displayedDislikeCount,
+  currentReactionType,
+  isReacting,
+  reactionErrorMessage,
   onDelete,
   onReact,
   onRetryComments,
@@ -155,9 +162,6 @@ export function BoardDetailContent({
   onUpdateComment,
   onDeleteComment,
   onChangeCommentPage,
-  currentReactionType,
-  isReacting,
-  reactionErrorMessage,
 }: BoardDetailContentProps) {
   const [draftComment, setDraftComment] = useState('');
   const [replyTargetId, setReplyTargetId] = useState<number | null>(null);
@@ -169,8 +173,6 @@ export function BoardDetailContent({
   const [editError, setEditError] = useState<{ commentId: number; message: string } | null>(null);
   const [deleteError, setDeleteError] = useState<{ commentId: number; message: string } | null>(null);
 
-  const likeCount = board.likeCount ?? 0;
-  const dislikeCount = board.dislikeCount ?? 0;
   const commentCount = board.commentCount ?? pageInfo?.totalElements ?? comments.length;
   const authorName = board.nickname.trim() || DETAIL_COPY.authorFallback;
   const imageUrls = board.imageFileUrls.filter((imageUrl) => imageUrl.trim().length > 0);
@@ -332,7 +334,7 @@ export function BoardDetailContent({
                   <ReactionButton
                     reactionType="LIKE"
                     label="좋아요"
-                    count={likeCount}
+                    count={displayedLikeCount}
                     active={currentReactionType === 'LIKE'}
                     disabled={isReacting}
                     onClick={() => void onReact('LIKE')}
@@ -340,7 +342,7 @@ export function BoardDetailContent({
                   <ReactionButton
                     reactionType="DISLIKE"
                     label="싫어요"
-                    count={dislikeCount}
+                    count={displayedDislikeCount}
                     active={currentReactionType === 'DISLIKE'}
                     disabled={isReacting}
                     onClick={() => void onReact('DISLIKE')}

--- a/src/pages/community/BoardDetailPage.tsx
+++ b/src/pages/community/BoardDetailPage.tsx
@@ -1,5 +1,5 @@
 ﻿import type { ReactNode } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useCurrentUser } from '@/features/auth';
@@ -21,7 +21,7 @@ import {
   useDeleteComment,
   useUpdateComment,
 } from '@/features/community';
-import { getApiErrorMessage } from '@/shared/lib/api/errorMessage';
+import { getApiErrorMessage, getApiErrorStatus } from '@/shared/lib/api/errorMessage';
 import { LoadingSpinner } from '@/shared/ui';
 
 const DETAIL_PAGE_COPY = {
@@ -32,7 +32,19 @@ const DETAIL_PAGE_COPY = {
   loadFailedFallback: '게시글 조회에 실패했어요. 잠시 후 다시 시도해주세요.',
   retry: '다시 시도',
   deleteFailedFallback: '게시글을 삭제하지 못했어요. 잠시 후 다시 시도해주세요.',
+  ownReactionNotice: '내가 작성한 게시물에는 반응을 남길 수 없어요.',
+  likeConflictNotice: '이미 좋아요를 누른 게시물이에요.',
+  dislikeConflictNotice: '이미 싫어요를 누른 게시물이에요.',
 };
+
+function getNextReactionType(currentReactionType: 'LIKE' | 'DISLIKE' | null, clickedReactionType: 'LIKE' | 'DISLIKE') {
+  return currentReactionType === clickedReactionType ? null : clickedReactionType;
+}
+
+interface ReactionOverrideState {
+  boardId: number | null;
+  reactionType: 'LIKE' | 'DISLIKE' | null;
+}
 
 function parseBoardId(value: string | undefined): number | null {
   if (!value) return null;
@@ -61,8 +73,28 @@ export function BoardDetailPage() {
   const { mutateAsync: deleteComment, isPending: isDeletingComment } = useDeleteComment();
   const { mutateAsync: reactToBoard, isPending: isReacting } = useBoardReaction();
   const [reactionError, setReactionError] = useState('');
+  const [reactionNotice, setReactionNotice] = useState('');
+  const [reactionOverride, setReactionOverride] = useState<ReactionOverrideState | null>(null);
 
   const canManage = Boolean(board && nickname && board.nickname.trim() === nickname.trim());
+  const serverReactionType = getBoardReactionType(board);
+  const currentReactionType =
+    reactionOverride?.boardId === boardId ? reactionOverride.reactionType : serverReactionType;
+
+  useEffect(() => {
+    const timer =
+      reactionNotice.length > 0
+        ? window.setTimeout(() => {
+            setReactionNotice('');
+          }, 5000)
+        : null;
+
+    return () => {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [reactionNotice]);
 
   const handleDelete = async () => {
     if (boardId === null) return;
@@ -166,14 +198,37 @@ export function BoardDetailPage() {
   };
 
   const handleBoardReaction = async (reactionType: 'LIKE' | 'DISLIKE') => {
+    if (canManage) {
+      setReactionError('');
+      setReactionNotice(DETAIL_PAGE_COPY.ownReactionNotice);
+      return;
+    }
+
+    const previousReactionType = currentReactionType;
+    const nextReactionType = getNextReactionType(previousReactionType, reactionType);
+
     try {
       setReactionError('');
+      setReactionNotice('');
+      setReactionOverride({ boardId, reactionType: nextReactionType });
       await reactToBoard({
         boardId,
         nextReactionType: reactionType,
-        currentReactionType: getBoardReactionType(board),
+        currentReactionType: previousReactionType,
       });
     } catch (reactionActionError) {
+      setReactionOverride(null);
+      const status = getApiErrorStatus(reactionActionError);
+
+      if (status === 409) {
+        setReactionError('');
+        setReactionNotice(
+          reactionType === 'LIKE' ? DETAIL_PAGE_COPY.likeConflictNotice : DETAIL_PAGE_COPY.dislikeConflictNotice,
+        );
+        void refetch();
+        return;
+      }
+
       setReactionError(
         getApiErrorMessage(
           reactionActionError,
@@ -186,6 +241,7 @@ export function BoardDetailPage() {
 
   return (
     <PageShell>
+      {reactionNotice ? <ToastMessage message={reactionNotice} /> : null}
       <CommunityLayout
         content={
           <BoardDetailContent
@@ -207,7 +263,9 @@ export function BoardDetailPage() {
             isCreatingComment={isCreatingComment}
             isUpdatingComment={isUpdatingComment}
             isDeletingComment={isDeletingComment}
-            currentReactionType={getBoardReactionType(board)}
+            displayedLikeCount={board.likeCount ?? 0}
+            displayedDislikeCount={board.dislikeCount ?? 0}
+            currentReactionType={currentReactionType}
             isReacting={isReacting}
             reactionErrorMessage={reactionError}
             onDelete={() => setDeleteDialogOpen(true)}
@@ -238,6 +296,16 @@ export function BoardDetailPage() {
 
 function PageShell({ children }: { children: ReactNode }) {
   return <>{children}</>;
+}
+
+function ToastMessage({ message }: { message: string }) {
+  return (
+    <div className="fixed left-1/2 top-6 z-50 -translate-x-1/2 px-4">
+      <div className="rounded-2xl bg-neutral-950 px-5 py-3 text-sm font-medium text-white shadow-[0_18px_42px_rgba(15,23,42,0.18)]">
+        {message}
+      </div>
+    </div>
+  );
 }
 
 function InvalidBoardState() {

--- a/src/pages/community/BoardDetailPage.tsx
+++ b/src/pages/community/BoardDetailPage.tsx
@@ -12,7 +12,10 @@ import {
   COMMENT_MUTATION_STATUS_MESSAGES,
   CommunityLayout,
   DeleteBoardDialog,
+  clearStoredBoardReactionType,
   getBoardReactionType,
+  getStoredBoardReactionType,
+  setStoredBoardReactionType,
   useBoardDetail,
   useBoardReaction,
   useCommentList,
@@ -39,11 +42,6 @@ const DETAIL_PAGE_COPY = {
 
 function getNextReactionType(currentReactionType: 'LIKE' | 'DISLIKE' | null, clickedReactionType: 'LIKE' | 'DISLIKE') {
   return currentReactionType === clickedReactionType ? null : clickedReactionType;
-}
-
-interface ReactionOverrideState {
-  boardId: number | null;
-  reactionType: 'LIKE' | 'DISLIKE' | null;
 }
 
 function parseBoardId(value: string | undefined): number | null {
@@ -74,12 +72,11 @@ export function BoardDetailPage() {
   const { mutateAsync: reactToBoard, isPending: isReacting } = useBoardReaction();
   const [reactionError, setReactionError] = useState('');
   const [reactionNotice, setReactionNotice] = useState('');
-  const [reactionOverride, setReactionOverride] = useState<ReactionOverrideState | null>(null);
 
   const canManage = Boolean(board && nickname && board.nickname.trim() === nickname.trim());
   const serverReactionType = getBoardReactionType(board);
   const currentReactionType =
-    reactionOverride?.boardId === boardId ? reactionOverride.reactionType : serverReactionType;
+    boardId !== null ? (serverReactionType ?? getStoredBoardReactionType(boardId)) : serverReactionType;
 
   useEffect(() => {
     const timer =
@@ -95,6 +92,14 @@ export function BoardDetailPage() {
       }
     };
   }, [reactionNotice]);
+
+  useEffect(() => {
+    if (boardId === null || serverReactionType === null) {
+      return;
+    }
+
+    setStoredBoardReactionType(boardId, serverReactionType);
+  }, [boardId, serverReactionType]);
 
   const handleDelete = async () => {
     if (boardId === null) return;
@@ -204,20 +209,22 @@ export function BoardDetailPage() {
       return;
     }
 
-    const previousReactionType = currentReactionType;
-    const nextReactionType = getNextReactionType(previousReactionType, reactionType);
+    const nextReactionType = getNextReactionType(currentReactionType, reactionType);
 
     try {
       setReactionError('');
       setReactionNotice('');
-      setReactionOverride({ boardId, reactionType: nextReactionType });
       await reactToBoard({
         boardId,
         nextReactionType: reactionType,
-        currentReactionType: previousReactionType,
+        currentReactionType,
       });
+      if (nextReactionType === null) {
+        clearStoredBoardReactionType(boardId);
+      } else {
+        setStoredBoardReactionType(boardId, nextReactionType);
+      }
     } catch (reactionActionError) {
-      setReactionOverride(null);
       const status = getApiErrorStatus(reactionActionError);
 
       if (status === 409) {

--- a/src/pages/community/BoardDetailPage.tsx
+++ b/src/pages/community/BoardDetailPage.tsx
@@ -6,12 +6,15 @@ import { useCurrentUser } from '@/features/auth';
 import {
   BOARD_DETAIL_STATUS_MESSAGES,
   BOARD_MUTATION_STATUS_MESSAGES,
+  BOARD_REACTION_STATUS_MESSAGES,
   BoardDetailContent,
   COMMENT_LIST_STATUS_MESSAGES,
   COMMENT_MUTATION_STATUS_MESSAGES,
   CommunityLayout,
   DeleteBoardDialog,
+  getBoardReactionType,
   useBoardDetail,
+  useBoardReaction,
   useCommentList,
   useCreateComment,
   useDeleteBoard,
@@ -56,6 +59,8 @@ export function BoardDetailPage() {
   const { mutateAsync: createComment, isPending: isCreatingComment } = useCreateComment();
   const { mutateAsync: updateComment, isPending: isUpdatingComment } = useUpdateComment();
   const { mutateAsync: deleteComment, isPending: isDeletingComment } = useDeleteComment();
+  const { mutateAsync: reactToBoard, isPending: isReacting } = useBoardReaction();
+  const [reactionError, setReactionError] = useState('');
 
   const canManage = Boolean(board && nickname && board.nickname.trim() === nickname.trim());
 
@@ -160,6 +165,25 @@ export function BoardDetailPage() {
     }
   };
 
+  const handleBoardReaction = async (reactionType: 'LIKE' | 'DISLIKE') => {
+    try {
+      setReactionError('');
+      await reactToBoard({
+        boardId,
+        nextReactionType: reactionType,
+        currentReactionType: getBoardReactionType(board),
+      });
+    } catch (reactionActionError) {
+      setReactionError(
+        getApiErrorMessage(
+          reactionActionError,
+          '반응을 처리하지 못했어요. 잠시 후 다시 시도해주세요.',
+          BOARD_REACTION_STATUS_MESSAGES,
+        ),
+      );
+    }
+  };
+
   return (
     <PageShell>
       <CommunityLayout
@@ -183,7 +207,11 @@ export function BoardDetailPage() {
             isCreatingComment={isCreatingComment}
             isUpdatingComment={isUpdatingComment}
             isDeletingComment={isDeletingComment}
+            currentReactionType={getBoardReactionType(board)}
+            isReacting={isReacting}
+            reactionErrorMessage={reactionError}
             onDelete={() => setDeleteDialogOpen(true)}
+            onReact={handleBoardReaction}
             onRetryComments={() => void commentsQuery.refetch()}
             onCreateComment={handleCreateComment}
             onUpdateComment={handleUpdateComment}

--- a/src/shared/lib/react-query/queryKey.ts
+++ b/src/shared/lib/react-query/queryKey.ts
@@ -6,6 +6,7 @@ export const queryKeys = {
     detail: (boardId: number) => ['boards', boardId, 'detail'] as const,
     comments: (boardId: number, params?: { page?: number; size?: number }) =>
       ['boards', boardId, 'comments', params?.page ?? 0, params?.size ?? 20] as const,
+    mineAll: () => ['boards', 'mine'] as const,
     mine: (params?: { page?: number; size?: number }) =>
       ['boards', 'mine', params?.page ?? 0, params?.size ?? 10] as const,
     tempSaved: (sessionKey: string) => ['boards', 'temp-save', sessionKey] as const,


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 커뮤니티 게시글 좋아요/싫어요 반응 기능 구현
- 반응 추가, 변경, 취소 API 연동
- 게시글 상세 화면에 좋아요/싫어요 수 및 반응 버튼 반영
- 커뮤니티 목록에서는 좋아요 수만 보이도록 유지
- 내가 누른 반응이 active 상태로 유지되도록 처리
- 반대 반응 선택 시 기존 반응이 정상적으로 변경되도록 수정
- 내 게시물 반응 시 안내 토스트가 노출되도록 UX 개선
- 중복 반응(409) 상황을 토스트로 안내하도록 처리

<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #56 
-   Closes: #57 

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

<img width="2074" height="978" alt="image" src="https://github.com/user-attachments/assets/54acb555-9b9c-4442-90ef-1e78b96fcd81" />

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.
