### PR TITLE
✨Feat: 메인 홈 반려동물 선택형 건강 레포트 UI 및 데이터 연동

### DIFF
--- a/src/pages/main/api/home.ts
+++ b/src/pages/main/api/home.ts
@@ -1,0 +1,8 @@
+import { apiClient } from '@/shared/api/axios';
+
+import type { MainHomeResponse } from '../model/types';
+
+export async function getMainHome(): Promise<MainHomeResponse> {
+  const response = await apiClient.get<MainHomeResponse>('/main');
+  return response.data;
+}

--- a/src/pages/main/model/formatters.ts
+++ b/src/pages/main/model/formatters.ts
@@ -32,10 +32,26 @@ export function formatDateLabel(value: string) {
   }).format(date);
 }
 
-export function getLatestReportByPet<T extends { petId: number; checkupDate: string }>(petId: number, reports: T[]) {
-  return [...reports]
-    .filter((report) => report.petId === petId)
-    .sort((left, right) => new Date(right.checkupDate).getTime() - new Date(left.checkupDate).getTime())[0];
+export function getLatestReportByPet<T extends { petId: number; checkupDate: string }>(
+  petId: number,
+  reports: T[],
+): T | undefined {
+  let latest: T | undefined;
+  let latestTime = -1;
+
+  for (const report of reports) {
+    if (report.petId !== petId) {
+      continue;
+    }
+
+    const time = new Date(report.checkupDate).getTime();
+    if (!Number.isNaN(time) && time > latestTime) {
+      latestTime = time;
+      latest = report;
+    }
+  }
+
+  return latest;
 }
 
 export function summarizeContent(value: string, maxLength = 140) {
@@ -50,19 +66,41 @@ export function summarizeContent(value: string, maxLength = 140) {
 
 interface ParsedHealthReportContent {
   recommendations?: unknown;
+  content?: unknown;
+  summary?: unknown;
+  analysis?: unknown;
+  message?: unknown;
 }
 
 export function extractHealthReportRecommendations(content: string): string[] {
   if (!content.trim()) return [];
 
   try {
-    const parsed = JSON.parse(content) as ParsedHealthReportContent;
-    if (!Array.isArray(parsed.recommendations)) {
+    const parsed = JSON.parse(content) as ParsedHealthReportContent | null;
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.recommendations)) {
       return [];
     }
 
     return parsed.recommendations.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
   } catch {
     return [];
+  }
+}
+
+export function extractHealthReportDisplayContent(content: string): string | null {
+  if (!content.trim()) return null;
+
+  try {
+    const parsed = JSON.parse(content) as ParsedHealthReportContent | null;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    const candidates = [parsed.content, parsed.summary, parsed.analysis, parsed.message];
+    const text = candidates.find((item): item is string => typeof item === 'string' && item.trim().length > 0);
+
+    return text?.trim() ?? null;
+  } catch {
+    return content;
   }
 }

--- a/src/pages/main/model/formatters.ts
+++ b/src/pages/main/model/formatters.ts
@@ -1,0 +1,58 @@
+const SPECIES_LABEL: Record<string, string> = {
+  CANINE: '강아지',
+  FELINE: '고양이',
+};
+
+const SEX_LABEL: Record<string, string> = {
+  MALE: '남아',
+  FEMALE: '여아',
+  NEUTER: '중성화',
+};
+
+export function getMainPetSpecies(profile: { species?: string; spercies?: string }) {
+  return profile.species ?? profile.spercies ?? '';
+}
+
+export function formatSpeciesLabel(species: string) {
+  return SPECIES_LABEL[species] ?? species;
+}
+
+export function formatSexLabel(sex: string) {
+  return SEX_LABEL[sex] ?? sex;
+}
+
+export function formatWeightLabel(weight: number) {
+  if (!Number.isFinite(weight)) return '-';
+  return `${weight.toFixed(1)}kg`;
+}
+
+export function formatDateLabel(value: string) {
+  if (!value) return '-';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value.slice(0, 10);
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+export function getLatestReportByPet<T extends { petId: number; checkupDate: string }>(petId: number, reports: T[]) {
+  return [...reports]
+    .filter((report) => report.petId === petId)
+    .sort((left, right) => new Date(right.checkupDate).getTime() - new Date(left.checkupDate).getTime())[0];
+}
+
+export function summarizeContent(value: string, maxLength = 140) {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength).trimEnd()}...`;
+}

--- a/src/pages/main/model/formatters.ts
+++ b/src/pages/main/model/formatters.ts
@@ -3,12 +3,6 @@ const SPECIES_LABEL: Record<string, string> = {
   FELINE: '고양이',
 };
 
-const SEX_LABEL: Record<string, string> = {
-  MALE: '남아',
-  FEMALE: '여아',
-  NEUTER: '중성화',
-};
-
 export function getMainPetSpecies(profile: { species?: string; spercies?: string }) {
   return profile.species ?? profile.spercies ?? '';
 }
@@ -17,13 +11,10 @@ export function formatSpeciesLabel(species: string) {
   return SPECIES_LABEL[species] ?? species;
 }
 
-export function formatSexLabel(sex: string) {
-  return SEX_LABEL[sex] ?? sex;
-}
-
 export function formatWeightLabel(weight: number) {
   if (!Number.isFinite(weight)) return '-';
-  return `${weight.toFixed(1)}kg`;
+  if (Number.isInteger(weight)) return `${weight} kg`;
+  return `${weight.toFixed(1)} kg`;
 }
 
 export function formatDateLabel(value: string) {
@@ -55,4 +46,23 @@ export function summarizeContent(value: string, maxLength = 140) {
   }
 
   return `${normalized.slice(0, maxLength).trimEnd()}...`;
+}
+
+interface ParsedHealthReportContent {
+  recommendations?: unknown;
+}
+
+export function extractHealthReportRecommendations(content: string): string[] {
+  if (!content.trim()) return [];
+
+  try {
+    const parsed = JSON.parse(content) as ParsedHealthReportContent;
+    if (!Array.isArray(parsed.recommendations)) {
+      return [];
+    }
+
+    return parsed.recommendations.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+  } catch {
+    return [];
+  }
 }

--- a/src/pages/main/model/quickLinks.tsx
+++ b/src/pages/main/model/quickLinks.tsx
@@ -12,7 +12,7 @@ export type QuickLinkItem = {
   Icon: ComponentType<SVGProps<SVGSVGElement>>;
 };
 
-/** 홈 화면 바로가기 메뉴(정적 네비게이션 설정, API 데이터 아님) */
+/** 메인 화면 바로가기 메뉴(정적 내비게이션, API 데이터 아님) */
 export const QUICK_LINKS: QuickLinkItem[] = [
   { id: 'pet', label: '나의 반려동물', to: '/my', Icon: PetIcon },
   { id: 'walk', label: '산책 기록', to: '/walk', Icon: WalkIcon },

--- a/src/pages/main/model/types.ts
+++ b/src/pages/main/model/types.ts
@@ -1,0 +1,35 @@
+export interface MainPetProfile {
+  petId: number;
+  name: string;
+  imageFileUrl: string | null;
+  breed: string;
+  age: number;
+  species?: string;
+  spercies?: string;
+  sex: string;
+  weight: number;
+}
+
+export interface MainHealthReport {
+  petId: number;
+  petName: string;
+  dashboardId: number;
+  healthReportTitle: string;
+  healthReportSummary: string;
+  healthReportContent: string;
+  checkupDate: string;
+}
+
+export interface MainAnnouncement {
+  boardTitle: string;
+  boardContent: string;
+  imageFileUrl: string | null;
+  viewCount: number;
+}
+
+export interface MainHomeResponse {
+  message: string;
+  petProfiles: MainPetProfile[];
+  healthReports: MainHealthReport[];
+  announcement: MainAnnouncement[];
+}

--- a/src/pages/main/model/useHomeDashboard.ts
+++ b/src/pages/main/model/useHomeDashboard.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMainHome } from '@/pages/main/api/home';
+import { queryKeys } from '@/shared/lib/react-query/queryKey';
+
+export function useHomeDashboard() {
+  return useQuery({
+    queryKey: queryKeys.main.home(),
+    queryFn: getMainHome,
+  });
+}

--- a/src/pages/main/ui/LoggedInHome.tsx
+++ b/src/pages/main/ui/LoggedInHome.tsx
@@ -1,13 +1,49 @@
+import { useState } from 'react';
+
+import { getApiErrorMessage } from '@/shared/lib/api/errorMessage';
+
+import { getLatestReportByPet } from '../model/formatters';
+import { useHomeDashboard } from '../model/useHomeDashboard';
 import { HealthReportSection } from './sections/HealthReportSection';
-import { HotTopicSection } from './sections/HotTopicSection';
 import { NoticeAndQuickLinksSection } from './sections/NoticeAndQuickLinksSection';
 
 export function LoggedInHome() {
+  const { data, isLoading, isError, error, refetch, isFetching } = useHomeDashboard();
+  const [selectedPetId, setSelectedPetId] = useState<number | null>(null);
+
+  const petProfiles = data?.petProfiles ?? [];
+  const healthReports = data?.healthReports ?? [];
+  const announcements = data?.announcement ?? [];
+
+  const resolvedSelectedPetId =
+    selectedPetId !== null && petProfiles.some((pet) => pet.petId === selectedPetId)
+      ? selectedPetId
+      : (petProfiles[0]?.petId ?? null);
+  const selectedPet = petProfiles.find((pet) => pet.petId === resolvedSelectedPetId) ?? null;
+  const selectedReport = selectedPet ? getLatestReportByPet(selectedPet.petId, healthReports) : undefined;
+  const errorMessage = isError
+    ? getApiErrorMessage(error, '메인 정보를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.')
+    : null;
+
   return (
-    <div className="flex w-full flex-col gap-4 pb-6 sm:gap-6">
-      <HealthReportSection />
-      <NoticeAndQuickLinksSection />
-      <HotTopicSection />
+    <div className="flex w-full flex-col gap-4 pb-8 sm:gap-6">
+      <HealthReportSection
+        isLoading={isLoading || isFetching}
+        errorMessage={errorMessage}
+        pets={petProfiles}
+        selectedPet={selectedPet}
+        selectedPetId={resolvedSelectedPetId}
+        selectedReport={selectedReport}
+        onSelectPet={setSelectedPetId}
+        onRetry={() => {
+          void refetch();
+        }}
+      />
+      <NoticeAndQuickLinksSection
+        isLoading={isLoading || isFetching}
+        errorMessage={errorMessage}
+        announcements={announcements}
+      />
     </div>
   );
 }

--- a/src/pages/main/ui/LoggedInHome.tsx
+++ b/src/pages/main/ui/LoggedInHome.tsx
@@ -9,7 +9,7 @@ import { HotTopicSection } from './sections/HotTopicSection';
 import { NoticeAndQuickLinksSection } from './sections/NoticeAndQuickLinksSection';
 
 export function LoggedInHome() {
-  const { data, isLoading, isError, error, refetch, isFetching } = useHomeDashboard();
+  const { data, isLoading, isError, error, refetch } = useHomeDashboard();
   const [selectedPetId, setSelectedPetId] = useState<number | null>(null);
 
   const petProfiles = data?.petProfiles ?? [];
@@ -28,7 +28,7 @@ export function LoggedInHome() {
   return (
     <div className="flex w-full flex-col gap-4 pb-6 sm:gap-6">
       <HealthReportSection
-        isLoading={isLoading || isFetching}
+        isLoading={isLoading}
         errorMessage={errorMessage}
         pets={petProfiles}
         selectedPet={selectedPet}

--- a/src/pages/main/ui/LoggedInHome.tsx
+++ b/src/pages/main/ui/LoggedInHome.tsx
@@ -5,6 +5,7 @@ import { getApiErrorMessage } from '@/shared/lib/api/errorMessage';
 import { getLatestReportByPet } from '../model/formatters';
 import { useHomeDashboard } from '../model/useHomeDashboard';
 import { HealthReportSection } from './sections/HealthReportSection';
+import { HotTopicSection } from './sections/HotTopicSection';
 import { NoticeAndQuickLinksSection } from './sections/NoticeAndQuickLinksSection';
 
 export function LoggedInHome() {
@@ -13,7 +14,6 @@ export function LoggedInHome() {
 
   const petProfiles = data?.petProfiles ?? [];
   const healthReports = data?.healthReports ?? [];
-  const announcements = data?.announcement ?? [];
 
   const resolvedSelectedPetId =
     selectedPetId !== null && petProfiles.some((pet) => pet.petId === selectedPetId)
@@ -26,7 +26,7 @@ export function LoggedInHome() {
     : null;
 
   return (
-    <div className="flex w-full flex-col gap-4 pb-8 sm:gap-6">
+    <div className="flex w-full flex-col gap-4 pb-6 sm:gap-6">
       <HealthReportSection
         isLoading={isLoading || isFetching}
         errorMessage={errorMessage}
@@ -39,11 +39,8 @@ export function LoggedInHome() {
           void refetch();
         }}
       />
-      <NoticeAndQuickLinksSection
-        isLoading={isLoading || isFetching}
-        errorMessage={errorMessage}
-        announcements={announcements}
-      />
+      <NoticeAndQuickLinksSection />
+      <HotTopicSection />
     </div>
   );
 }

--- a/src/pages/main/ui/sections/HealthReportSection.tsx
+++ b/src/pages/main/ui/sections/HealthReportSection.tsx
@@ -1,16 +1,17 @@
 import { Link } from 'react-router-dom';
 
+import { PetImage } from '@/features/family-management/ui/FamilyVisuals';
 import DoctorIcon from '@/pages/main/assets/doctor.svg?react';
 import FolderIcon from '@/pages/main/assets/report.svg?react';
-import RegisterPetIcon from '@/pages/main/assets/register-pet.svg?react';
+import PetIcon from '@/pages/main/assets/register-pet.svg?react';
 import type { MainHealthReport, MainPetProfile } from '@/pages/main/model/types';
-import { PetImage } from '@/features/family-management/ui/FamilyVisuals';
+import petDefaultCatIllustration from '@/shared/assets/images/pet-default-cat.svg';
+import petDefaultIllustration from '@/shared/assets/images/pet-default.svg';
 import { Skeleton } from '@/shared/ui';
 
 import {
+  extractHealthReportRecommendations,
   formatDateLabel,
-  formatSexLabel,
-  formatSpeciesLabel,
   formatWeightLabel,
   getMainPetSpecies,
   summarizeContent,
@@ -37,209 +38,240 @@ export function HealthReportSection({
   onSelectPet,
   onRetry,
 }: HealthReportSectionProps) {
+  if (isLoading) {
+    return (
+      <section className="w-full" aria-labelledby="home-health-report-heading">
+        <h2 id="home-health-report-heading" className="sr-only">
+          AI 건강 레포트
+        </h2>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:gap-5">
+          <article className="overflow-hidden rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm sm:p-6">
+            <div className="flex items-center gap-2">
+              <FolderIcon className="h-7 w-7 shrink-0" />
+              <span className="text-[16px] font-semibold text-neutral-900">AI 건강 레포트</span>
+            </div>
+
+            <div className="mt-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-5">
+              <Skeleton className="h-28 w-28 rounded-[24px] sm:h-32 sm:w-32" />
+              <div className="min-w-0 flex-1 space-y-3">
+                <Skeleton className="h-7 w-4/5 rounded-md" />
+                <Skeleton className="h-4 w-full rounded-md" />
+                <Skeleton className="h-4 w-5/6 rounded-md" />
+                <Skeleton className="h-4 w-2/3 rounded-md" />
+              </div>
+            </div>
+          </article>
+
+          <article className="overflow-hidden rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm sm:p-6">
+            <div className="flex items-start gap-4">
+              <Skeleton className="h-24 w-24 rounded-[20px]" />
+              <div className="flex-1 space-y-3">
+                <Skeleton className="h-7 w-24 rounded-md" />
+                <Skeleton className="h-4 w-20 rounded-md" />
+                <Skeleton className="h-4 w-24 rounded-md" />
+                <Skeleton className="h-4 w-20 rounded-md" />
+              </div>
+            </div>
+            <div className="mt-4 flex gap-2.5 border-t border-neutral-200 pt-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <Skeleton key={index} className="h-12 w-12 rounded-[12px]" />
+              ))}
+            </div>
+          </article>
+        </div>
+      </section>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <section className="w-full" aria-labelledby="home-health-report-heading">
+        <h2 id="home-health-report-heading" className="sr-only">
+          AI 건강 레포트
+        </h2>
+
+        <div className="rounded-2xl border border-red-100 bg-red-50/60 p-5 shadow-sm sm:p-6">
+          <p className="text-sm leading-6 text-red-500">{errorMessage}</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-4 inline-flex min-h-11 items-center justify-center rounded-xl bg-brand px-5 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90"
+          >
+            다시 불러오기
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  if (!selectedPet) {
+    return (
+      <section className="w-full" aria-labelledby="home-health-report-heading">
+        <h2 id="home-health-report-heading" className="sr-only">
+          AI 건강 레포트
+        </h2>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:gap-5">
+          <article className="overflow-hidden rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm sm:p-6 md:p-7">
+            <div className="flex items-center gap-2">
+              <FolderIcon className="h-7 w-7 shrink-0" />
+              <span className="text-[16px] font-semibold text-neutral-900">AI 건강 레포트</span>
+            </div>
+
+            <div className="mt-5 flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
+              <DoctorIcon className="mx-auto h-32 w-32 shrink-0 sm:mx-0 sm:h-40 sm:w-40" />
+              <div className="min-w-0 flex-1">
+                <h3 className="font-display text-lg font-bold leading-snug text-neutral-900 sm:text-xl">
+                  반려동물을 등록하고
+                  <br className="hidden sm:block" /> 건강 레포트를 받아보세요!
+                </h3>
+                <p className="mt-3 text-[14px] leading-relaxed text-neutral-600">
+                  산책·식사·활동 기록을 기반으로 한 AI 건강 리포트를 제공합니다.
+                  <br />
+                  지금 반려동물을 등록하고 관리 기록을 시작해보세요!
+                </p>
+              </div>
+            </div>
+          </article>
+
+          <article className="flex flex-col items-center justify-center gap-5 rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm sm:gap-6 sm:p-6 md:p-7">
+            <PetIcon className="h-24 w-24 sm:h-28 sm:w-28" />
+            <p className="text-center text-sm font-medium leading-relaxed text-neutral-700">
+              반려동물을 등록하고
+              <br />
+              다양한 서비스를 경험해 보세요!
+            </p>
+            <Link
+              to="/my"
+              className="inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-brand px-6 text-sm font-bold text-brand-foreground transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+            >
+              반려동물 등록하기
+            </Link>
+          </article>
+        </div>
+      </section>
+    );
+  }
+
+  const selectedSpecies = getMainPetSpecies(selectedPet);
+  const reportRecommendations = selectedReport
+    ? extractHealthReportRecommendations(selectedReport.healthReportContent)
+    : [];
+  const reportPrimaryContent =
+    reportRecommendations[0] ||
+    selectedReport?.healthReportSummary ||
+    (selectedReport ? summarizeContent(selectedReport.healthReportContent, 96) : '');
+
   return (
     <section className="w-full" aria-labelledby="home-health-report-heading">
       <h2 id="home-health-report-heading" className="sr-only">
         AI 건강 레포트
       </h2>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.65fr)_minmax(320px,1fr)] lg:gap-5">
-        <article className="overflow-hidden rounded-[28px] border border-[#eadfd7] bg-[linear-gradient(135deg,#fff9f2_0%,#ffffff_48%,#fff4ea_100%)] p-5 shadow-[0_18px_50px_rgba(203,138,82,0.08)] sm:p-6 md:p-7">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:gap-5">
+        <article className="overflow-hidden rounded-[24px] border border-neutral-300 bg-white px-5 py-5 shadow-sm sm:px-6 sm:py-6">
           <div className="flex items-center gap-2">
             <FolderIcon className="h-7 w-7 shrink-0" />
-            <span className="text-[18px] font-semibold text-neutral-950">AI 건강 레포트</span>
+            <span className="text-[16px] font-semibold text-neutral-900">AI 건강 레포트</span>
           </div>
 
-          {isLoading ? (
-            <div className="mt-6 flex flex-col gap-5 sm:flex-row sm:items-center">
-              <Skeleton className="h-32 w-32 rounded-[28px] sm:h-40 sm:w-40" />
-              <div className="flex-1 space-y-3">
-                <Skeleton className="h-6 w-40 rounded-md" />
-                <Skeleton className="h-10 w-full rounded-md" />
-                <Skeleton className="h-4 w-full rounded-md" />
-                <Skeleton className="h-4 w-5/6 rounded-md" />
-              </div>
-            </div>
-          ) : errorMessage ? (
-            <div className="mt-6 rounded-[24px] border border-red-100 bg-white/90 p-5">
-              <p className="text-sm leading-6 text-red-500">{errorMessage}</p>
-              <button
-                type="button"
-                onClick={onRetry}
-                className="mt-4 inline-flex h-11 items-center justify-center rounded-xl bg-brand px-5 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90"
-              >
-                다시 불러오기
-              </button>
-            </div>
-          ) : !selectedPet ? (
-            <div className="mt-6 flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
-              <RegisterPetIcon className="mx-auto h-28 w-28 shrink-0 sm:mx-0 sm:h-36 sm:w-36" />
-              <div className="min-w-0 flex-1">
-                <span className="inline-flex rounded-full bg-white/80 px-3 py-1 text-xs font-semibold tracking-[0.12em] text-[#c46f3e]">
-                  WELCOME TO DODO
-                </span>
-                <h3 className="mt-4 text-xl font-bold leading-snug text-neutral-950 sm:text-[30px]">
-                  반려동물을 등록하고
-                  <br className="hidden sm:block" />
-                  맞춤 건강 레포트를 받아보세요
-                </h3>
-                <p className="mt-3 text-sm leading-7 text-neutral-600">
-                  반려동물 프로필과 기록이 쌓이면 메인에서 바로 확인할 수 있는 AI 건강 레포트를 제공해 드려요.
-                </p>
-                <Link
-                  to="/my/pets/new"
-                  className="mt-5 inline-flex min-h-12 items-center justify-center rounded-xl bg-brand px-6 text-sm font-bold text-brand-foreground transition-opacity hover:opacity-90"
-                >
-                  반려동물 등록하러 가기
-                </Link>
-              </div>
-            </div>
-          ) : (
-            <div className="mt-6 flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
-              <div className="mx-auto flex h-32 w-32 shrink-0 items-center justify-center rounded-[28px] bg-white/80 ring-1 ring-[#f2dcc9] sm:mx-0 sm:h-40 sm:w-40">
-                <DoctorIcon className="h-24 w-24 sm:h-32 sm:w-32" />
-              </div>
+          <div className="mt-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-5">
+            <DoctorIcon className="mx-auto h-28 w-28 shrink-0 sm:mx-0 sm:h-36 sm:w-36" />
 
-              <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="inline-flex rounded-full bg-white px-3 py-1 text-xs font-semibold text-[#c46f3e] ring-1 ring-[#f2dcc9]">
-                    {selectedPet.name} 맞춤 분석
-                  </span>
-                  {selectedReport ? (
-                    <span className="text-sm text-neutral-500">{formatDateLabel(selectedReport.checkupDate)} 기준</span>
-                  ) : null}
-                </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="text-[22px] font-bold leading-snug text-neutral-950 sm:text-[24px]">
+                {selectedReport?.healthReportTitle ?? `${selectedPet.name}의 건강 데이터를 분석 중이에요.`}
+              </h3>
 
+              <div className="mt-3 space-y-1 text-[14px] leading-7 text-neutral-800 sm:text-[15px]">
                 {selectedReport ? (
                   <>
-                    <h3 className="mt-4 text-xl font-bold leading-snug text-neutral-950 sm:text-[30px]">
-                      "{selectedReport.healthReportTitle}"
-                    </h3>
-                    <p className="mt-3 text-[15px] font-medium leading-7 text-neutral-700">
-                      {selectedReport.healthReportSummary}
-                    </p>
-                    <p className="mt-3 text-sm leading-7 text-neutral-500">
-                      {summarizeContent(selectedReport.healthReportContent)}
-                    </p>
+                    <p>{selectedReport.healthReportSummary}</p>
+                    <p>{reportPrimaryContent}</p>
+                    {reportRecommendations.length > 1 ? <p>{reportRecommendations[1]}</p> : null}
                   </>
                 ) : (
-                  <>
-                    <h3 className="mt-4 text-xl font-bold leading-snug text-neutral-950 sm:text-[30px]">
-                      {selectedPet.name}의 첫 건강 레포트를 준비해 볼까요?
-                    </h3>
-                    <p className="mt-3 text-sm leading-7 text-neutral-600">
-                      아직 등록된 AI 건강 레포트가 없어요. 산책, 체중, 특이사항 기록이 쌓이면 더 정교한 분석을 확인할 수
-                      있어요.
-                    </p>
-                  </>
+                  <p>{selectedPet.name}의 첫 건강 레포트를 만들 수 있도록 산책과 건강 기록을 조금 더 쌓아보세요.</p>
                 )}
+              </div>
 
-                <div className="mt-5 flex flex-wrap gap-3">
-                  <Link
-                    to={`/my/pets/${selectedPet.petId}`}
-                    className="inline-flex min-h-11 items-center justify-center rounded-xl bg-brand px-5 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90"
-                  >
-                    {selectedReport ? '반려동물 상세 보기' : '기록 관리하러 가기'}
-                  </Link>
-                  <Link
-                    to="/walk"
-                    className="inline-flex min-h-11 items-center justify-center rounded-xl border border-neutral-200 bg-white px-5 text-sm font-semibold text-neutral-800 transition-colors hover:border-brand/40 hover:text-brand"
-                  >
-                    산책 기록 보러가기
-                  </Link>
-                </div>
+              <div className="mt-4 flex justify-end">
+                <span className="shrink-0 text-[14px] text-neutral-400">
+                  {selectedReport ? formatDateLabel(selectedReport.checkupDate) : '레포트 준비 중'}
+                </span>
               </div>
             </div>
-          )}
+          </div>
         </article>
 
-        <article className="overflow-hidden rounded-[28px] border border-neutral-200 bg-white shadow-sm">
-          <div className="border-b border-neutral-100 px-5 py-5 sm:px-6 sm:py-6">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <p className="text-[11px] font-semibold tracking-[0.16em] text-neutral-400">SELECT PET</p>
-                <h3 className="mt-2 text-[22px] font-semibold text-neutral-950">반려동물 프로필</h3>
+        <article className="overflow-hidden rounded-[24px] border border-neutral-300 bg-white shadow-sm">
+          <div className="px-4 py-4 sm:px-5 sm:py-5">
+            <div className="flex items-start gap-3.5">
+              <div className="h-[96px] w-[96px] overflow-hidden rounded-[18px]">
+                <PetImage src={selectedPet.imageFileUrl} alt={selectedPet.name} species={selectedSpecies} />
               </div>
-              {pets.length > 0 ? (
-                <span className="rounded-full bg-[#fff4ea] px-3 py-1 text-xs font-semibold text-[#c46f3e]">
-                  총 {pets.length}마리
-                </span>
-              ) : null}
-            </div>
 
-            {isLoading ? (
-              <div className="mt-5 flex items-center gap-4">
-                <Skeleton className="h-24 w-24 rounded-[20px]" />
-                <div className="flex-1 space-y-3">
-                  <Skeleton className="h-6 w-24 rounded-md" />
-                  <Skeleton className="h-4 w-28 rounded-md" />
-                  <Skeleton className="h-4 w-20 rounded-md" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start justify-between gap-3">
+                  <h3 className="truncate pt-0.5 text-[24px] font-bold leading-none text-neutral-950">
+                    {selectedPet.name}
+                  </h3>
+                  <span className="rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-600">
+                    만 {selectedPet.age}세
+                  </span>
                 </div>
-              </div>
-            ) : selectedPet ? (
-              <div className="mt-5 flex items-center gap-4">
-                <PetImage
-                  src={selectedPet.imageFileUrl}
-                  alt={selectedPet.name}
-                  species={getMainPetSpecies(selectedPet)}
-                />
-                <div className="min-w-0 flex-1">
-                  <h4 className="truncate text-[28px] font-bold text-neutral-950">{selectedPet.name}</h4>
-                  <div className="mt-3 space-y-1.5 text-sm text-neutral-600">
-                    <p>
-                      만 {selectedPet.age}세 · {formatSpeciesLabel(getMainPetSpecies(selectedPet))}
+
+                <div className="mt-4 grid grid-cols-2 gap-2.5">
+                  <div className="rounded-xl bg-neutral-50 px-3 py-2.5">
+                    <p className="text-[11px] font-semibold tracking-[0.08em] text-neutral-400">품종</p>
+                    <p className="mt-1 truncate text-sm font-semibold text-neutral-900">{selectedPet.breed || '-'}</p>
+                  </div>
+                  <div className="rounded-xl bg-neutral-50 px-3 py-2.5">
+                    <p className="text-[11px] font-semibold tracking-[0.08em] text-neutral-400">체중</p>
+                    <p className="mt-1 truncate text-sm font-semibold text-neutral-900">
+                      {formatWeightLabel(selectedPet.weight)}
                     </p>
-                    <p>
-                      {selectedPet.breed} · {formatSexLabel(selectedPet.sex)}
-                    </p>
-                    <p>{formatWeightLabel(selectedPet.weight)}</p>
                   </div>
                 </div>
               </div>
-            ) : (
-              <p className="mt-5 text-sm leading-7 text-neutral-500">아직 등록된 반려동물이 없어요.</p>
-            )}
+            </div>
           </div>
 
-          <div className="px-5 py-4 sm:px-6 sm:py-5">
-            {isLoading ? (
-              <div className="flex gap-3 overflow-hidden">
-                {Array.from({ length: 3 }).map((_, index) => (
-                  <Skeleton key={index} className="h-16 w-16 rounded-[18px]" />
-                ))}
-              </div>
-            ) : pets.length > 0 ? (
-              <div className="flex gap-3 overflow-x-auto pb-1">
-                {pets.map((pet) => {
-                  const species = getMainPetSpecies(pet);
-                  const isActive = pet.petId === selectedPetId;
+          <div className="border-t border-neutral-200 px-4 py-3 sm:px-5">
+            <div className="flex gap-2.5 overflow-x-auto pb-1">
+              {pets.map((pet) => {
+                const species = getMainPetSpecies(pet);
+                const fallbackImage = species === 'FELINE' ? petDefaultCatIllustration : petDefaultIllustration;
+                const isActive = pet.petId === selectedPetId;
 
-                  return (
-                    <button
-                      key={pet.petId}
-                      type="button"
-                      onClick={() => onSelectPet(pet.petId)}
-                      className={[
-                        'group flex shrink-0 flex-col items-center gap-2 rounded-[20px] border px-2 py-2 transition-all',
-                        isActive
-                          ? 'border-[#f0b37e] bg-[#fff4ea] shadow-[0_10px_25px_rgba(222,136,70,0.18)]'
-                          : 'border-neutral-200 bg-white hover:border-brand/40 hover:bg-[#fffaf5]',
-                      ].join(' ')}
-                    >
-                      <PetImage src={pet.imageFileUrl} alt={pet.name} species={species} />
-                      <span className="max-w-20 truncate text-sm font-semibold text-neutral-800">{pet.name}</span>
-                    </button>
-                  );
-                })}
-              </div>
-            ) : (
-              <Link
-                to="/my/pets/new"
-                className="inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-dashed border-neutral-300 bg-neutral-50 px-5 text-sm font-semibold text-neutral-700 transition-colors hover:border-brand/40 hover:text-brand"
-              >
-                첫 반려동물 등록하기
-              </Link>
-            )}
+                return (
+                  <button
+                    key={pet.petId}
+                    type="button"
+                    onClick={() => onSelectPet(pet.petId)}
+                    className={[
+                      'shrink-0 overflow-hidden rounded-[12px] border-2 transition-all',
+                      isActive ? 'border-[#f0c247] shadow-sm' : 'border-transparent opacity-80 hover:opacity-100',
+                    ].join(' ')}
+                    aria-pressed={isActive}
+                    aria-label={`${pet.name} 선택`}
+                  >
+                    <div className="flex h-[56px] w-[56px] items-center justify-center overflow-hidden rounded-[10px] bg-neutral-100 p-1">
+                      <img
+                        src={pet.imageFileUrl || fallbackImage}
+                        alt={pet.name}
+                        className="h-full w-full rounded-[8px] object-cover"
+                        onError={(event) => {
+                          event.currentTarget.onerror = null;
+                          event.currentTarget.src = fallbackImage;
+                        }}
+                      />
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </article>
       </div>

--- a/src/pages/main/ui/sections/HealthReportSection.tsx
+++ b/src/pages/main/ui/sections/HealthReportSection.tsx
@@ -159,9 +159,7 @@ export function HealthReportSection({
     ? extractHealthReportRecommendations(selectedReport.healthReportContent)
     : [];
   const reportPrimaryContent =
-    reportRecommendations[0] ||
-    selectedReport?.healthReportSummary ||
-    (selectedReport ? summarizeContent(selectedReport.healthReportContent, 96) : '');
+    reportRecommendations[0] || (selectedReport ? summarizeContent(selectedReport.healthReportContent, 96) : '');
 
   return (
     <section className="w-full" aria-labelledby="home-health-report-heading">

--- a/src/pages/main/ui/sections/HealthReportSection.tsx
+++ b/src/pages/main/ui/sections/HealthReportSection.tsx
@@ -2,51 +2,245 @@ import { Link } from 'react-router-dom';
 
 import DoctorIcon from '@/pages/main/assets/doctor.svg?react';
 import FolderIcon from '@/pages/main/assets/report.svg?react';
-import PetIcon from '@/pages/main/assets/register-pet.svg?react';
+import RegisterPetIcon from '@/pages/main/assets/register-pet.svg?react';
+import type { MainHealthReport, MainPetProfile } from '@/pages/main/model/types';
+import { PetImage } from '@/features/family-management/ui/FamilyVisuals';
+import { Skeleton } from '@/shared/ui';
 
-export function HealthReportSection() {
+import {
+  formatDateLabel,
+  formatSexLabel,
+  formatSpeciesLabel,
+  formatWeightLabel,
+  getMainPetSpecies,
+  summarizeContent,
+} from '../../model/formatters';
+
+interface HealthReportSectionProps {
+  isLoading: boolean;
+  errorMessage: string | null;
+  pets: MainPetProfile[];
+  selectedPetId: number | null;
+  selectedPet: MainPetProfile | null;
+  selectedReport?: MainHealthReport;
+  onSelectPet: (petId: number) => void;
+  onRetry: () => void;
+}
+
+export function HealthReportSection({
+  isLoading,
+  errorMessage,
+  pets,
+  selectedPetId,
+  selectedPet,
+  selectedReport,
+  onSelectPet,
+  onRetry,
+}: HealthReportSectionProps) {
   return (
     <section className="w-full" aria-labelledby="home-health-report-heading">
       <h2 id="home-health-report-heading" className="sr-only">
         AI 건강 레포트
       </h2>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:gap-5">
-        <article className="overflow-hidden rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm sm:p-6 md:p-7">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.65fr)_minmax(320px,1fr)] lg:gap-5">
+        <article className="overflow-hidden rounded-[28px] border border-[#eadfd7] bg-[linear-gradient(135deg,#fff9f2_0%,#ffffff_48%,#fff4ea_100%)] p-5 shadow-[0_18px_50px_rgba(203,138,82,0.08)] sm:p-6 md:p-7">
           <div className="flex items-center gap-2">
             <FolderIcon className="h-7 w-7 shrink-0" />
-            <span className="text-[16px] font-semibold text-neutral-900">AI 건강 레포트</span>
+            <span className="text-[18px] font-semibold text-neutral-950">AI 건강 레포트</span>
           </div>
 
-          <div className="mt-5 flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
-            <DoctorIcon className="mx-auto h-32 w-32 shrink-0 sm:mx-0 sm:h-40 sm:w-40" />
-            <div className="min-w-0 flex-1">
-              <h3 className="font-display text-lg font-bold leading-snug text-neutral-900 sm:text-xl">
-                반려동물을 등록하고
-                <br className="hidden sm:block" /> 건강 레포트를 받아보세요!
-              </h3>
-              <p className="mt-3 text-[14px] leading-relaxed text-neutral-600">
-                산책·식사·활동 기록을 기반으로 한 AI 건강 리포트를 제공합니다.
-                <br />
-                지금 반려동물을 등록하고 관리 기록을 시작해보세요!
-              </p>
+          {isLoading ? (
+            <div className="mt-6 flex flex-col gap-5 sm:flex-row sm:items-center">
+              <Skeleton className="h-32 w-32 rounded-[28px] sm:h-40 sm:w-40" />
+              <div className="flex-1 space-y-3">
+                <Skeleton className="h-6 w-40 rounded-md" />
+                <Skeleton className="h-10 w-full rounded-md" />
+                <Skeleton className="h-4 w-full rounded-md" />
+                <Skeleton className="h-4 w-5/6 rounded-md" />
+              </div>
             </div>
-          </div>
+          ) : errorMessage ? (
+            <div className="mt-6 rounded-[24px] border border-red-100 bg-white/90 p-5">
+              <p className="text-sm leading-6 text-red-500">{errorMessage}</p>
+              <button
+                type="button"
+                onClick={onRetry}
+                className="mt-4 inline-flex h-11 items-center justify-center rounded-xl bg-brand px-5 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90"
+              >
+                다시 불러오기
+              </button>
+            </div>
+          ) : !selectedPet ? (
+            <div className="mt-6 flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
+              <RegisterPetIcon className="mx-auto h-28 w-28 shrink-0 sm:mx-0 sm:h-36 sm:w-36" />
+              <div className="min-w-0 flex-1">
+                <span className="inline-flex rounded-full bg-white/80 px-3 py-1 text-xs font-semibold tracking-[0.12em] text-[#c46f3e]">
+                  WELCOME TO DODO
+                </span>
+                <h3 className="mt-4 text-xl font-bold leading-snug text-neutral-950 sm:text-[30px]">
+                  반려동물을 등록하고
+                  <br className="hidden sm:block" />
+                  맞춤 건강 레포트를 받아보세요
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-neutral-600">
+                  반려동물 프로필과 기록이 쌓이면 메인에서 바로 확인할 수 있는 AI 건강 레포트를 제공해 드려요.
+                </p>
+                <Link
+                  to="/my/pets/new"
+                  className="mt-5 inline-flex min-h-12 items-center justify-center rounded-xl bg-brand px-6 text-sm font-bold text-brand-foreground transition-opacity hover:opacity-90"
+                >
+                  반려동물 등록하러 가기
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-6 flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
+              <div className="mx-auto flex h-32 w-32 shrink-0 items-center justify-center rounded-[28px] bg-white/80 ring-1 ring-[#f2dcc9] sm:mx-0 sm:h-40 sm:w-40">
+                <DoctorIcon className="h-24 w-24 sm:h-32 sm:w-32" />
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="inline-flex rounded-full bg-white px-3 py-1 text-xs font-semibold text-[#c46f3e] ring-1 ring-[#f2dcc9]">
+                    {selectedPet.name} 맞춤 분석
+                  </span>
+                  {selectedReport ? (
+                    <span className="text-sm text-neutral-500">{formatDateLabel(selectedReport.checkupDate)} 기준</span>
+                  ) : null}
+                </div>
+
+                {selectedReport ? (
+                  <>
+                    <h3 className="mt-4 text-xl font-bold leading-snug text-neutral-950 sm:text-[30px]">
+                      "{selectedReport.healthReportTitle}"
+                    </h3>
+                    <p className="mt-3 text-[15px] font-medium leading-7 text-neutral-700">
+                      {selectedReport.healthReportSummary}
+                    </p>
+                    <p className="mt-3 text-sm leading-7 text-neutral-500">
+                      {summarizeContent(selectedReport.healthReportContent)}
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <h3 className="mt-4 text-xl font-bold leading-snug text-neutral-950 sm:text-[30px]">
+                      {selectedPet.name}의 첫 건강 레포트를 준비해 볼까요?
+                    </h3>
+                    <p className="mt-3 text-sm leading-7 text-neutral-600">
+                      아직 등록된 AI 건강 레포트가 없어요. 산책, 체중, 특이사항 기록이 쌓이면 더 정교한 분석을 확인할 수
+                      있어요.
+                    </p>
+                  </>
+                )}
+
+                <div className="mt-5 flex flex-wrap gap-3">
+                  <Link
+                    to={`/my/pets/${selectedPet.petId}`}
+                    className="inline-flex min-h-11 items-center justify-center rounded-xl bg-brand px-5 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90"
+                  >
+                    {selectedReport ? '반려동물 상세 보기' : '기록 관리하러 가기'}
+                  </Link>
+                  <Link
+                    to="/walk"
+                    className="inline-flex min-h-11 items-center justify-center rounded-xl border border-neutral-200 bg-white px-5 text-sm font-semibold text-neutral-800 transition-colors hover:border-brand/40 hover:text-brand"
+                  >
+                    산책 기록 보러가기
+                  </Link>
+                </div>
+              </div>
+            </div>
+          )}
         </article>
 
-        <article className="flex flex-col items-center justify-center gap-5 rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm sm:gap-6 sm:p-6 md:p-7">
-          <PetIcon className="h-24 w-24 sm:h-28 sm:w-28" />
-          <p className="text-center text-sm font-medium leading-relaxed text-neutral-700">
-            반려동물을 등록하고
-            <br />
-            다양한 서비스를 경험해 보세요!
-          </p>
-          <Link
-            to="/my"
-            className="inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-brand px-6 text-sm font-bold text-brand-foreground transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
-          >
-            반려동물 등록하기
-          </Link>
+        <article className="overflow-hidden rounded-[28px] border border-neutral-200 bg-white shadow-sm">
+          <div className="border-b border-neutral-100 px-5 py-5 sm:px-6 sm:py-6">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-[11px] font-semibold tracking-[0.16em] text-neutral-400">SELECT PET</p>
+                <h3 className="mt-2 text-[22px] font-semibold text-neutral-950">반려동물 프로필</h3>
+              </div>
+              {pets.length > 0 ? (
+                <span className="rounded-full bg-[#fff4ea] px-3 py-1 text-xs font-semibold text-[#c46f3e]">
+                  총 {pets.length}마리
+                </span>
+              ) : null}
+            </div>
+
+            {isLoading ? (
+              <div className="mt-5 flex items-center gap-4">
+                <Skeleton className="h-24 w-24 rounded-[20px]" />
+                <div className="flex-1 space-y-3">
+                  <Skeleton className="h-6 w-24 rounded-md" />
+                  <Skeleton className="h-4 w-28 rounded-md" />
+                  <Skeleton className="h-4 w-20 rounded-md" />
+                </div>
+              </div>
+            ) : selectedPet ? (
+              <div className="mt-5 flex items-center gap-4">
+                <PetImage
+                  src={selectedPet.imageFileUrl}
+                  alt={selectedPet.name}
+                  species={getMainPetSpecies(selectedPet)}
+                />
+                <div className="min-w-0 flex-1">
+                  <h4 className="truncate text-[28px] font-bold text-neutral-950">{selectedPet.name}</h4>
+                  <div className="mt-3 space-y-1.5 text-sm text-neutral-600">
+                    <p>
+                      만 {selectedPet.age}세 · {formatSpeciesLabel(getMainPetSpecies(selectedPet))}
+                    </p>
+                    <p>
+                      {selectedPet.breed} · {formatSexLabel(selectedPet.sex)}
+                    </p>
+                    <p>{formatWeightLabel(selectedPet.weight)}</p>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p className="mt-5 text-sm leading-7 text-neutral-500">아직 등록된 반려동물이 없어요.</p>
+            )}
+          </div>
+
+          <div className="px-5 py-4 sm:px-6 sm:py-5">
+            {isLoading ? (
+              <div className="flex gap-3 overflow-hidden">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <Skeleton key={index} className="h-16 w-16 rounded-[18px]" />
+                ))}
+              </div>
+            ) : pets.length > 0 ? (
+              <div className="flex gap-3 overflow-x-auto pb-1">
+                {pets.map((pet) => {
+                  const species = getMainPetSpecies(pet);
+                  const isActive = pet.petId === selectedPetId;
+
+                  return (
+                    <button
+                      key={pet.petId}
+                      type="button"
+                      onClick={() => onSelectPet(pet.petId)}
+                      className={[
+                        'group flex shrink-0 flex-col items-center gap-2 rounded-[20px] border px-2 py-2 transition-all',
+                        isActive
+                          ? 'border-[#f0b37e] bg-[#fff4ea] shadow-[0_10px_25px_rgba(222,136,70,0.18)]'
+                          : 'border-neutral-200 bg-white hover:border-brand/40 hover:bg-[#fffaf5]',
+                      ].join(' ')}
+                    >
+                      <PetImage src={pet.imageFileUrl} alt={pet.name} species={species} />
+                      <span className="max-w-20 truncate text-sm font-semibold text-neutral-800">{pet.name}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <Link
+                to="/my/pets/new"
+                className="inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-dashed border-neutral-300 bg-neutral-50 px-5 text-sm font-semibold text-neutral-700 transition-colors hover:border-brand/40 hover:text-brand"
+              >
+                첫 반려동물 등록하기
+              </Link>
+            )}
+          </div>
         </article>
       </div>
     </section>

--- a/src/pages/main/ui/sections/HealthReportSection.tsx
+++ b/src/pages/main/ui/sections/HealthReportSection.tsx
@@ -10,6 +10,7 @@ import petDefaultIllustration from '@/shared/assets/images/pet-default.svg';
 import { Skeleton } from '@/shared/ui';
 
 import {
+  extractHealthReportDisplayContent,
   extractHealthReportRecommendations,
   formatDateLabel,
   formatWeightLabel,
@@ -158,8 +159,14 @@ export function HealthReportSection({
   const reportRecommendations = selectedReport
     ? extractHealthReportRecommendations(selectedReport.healthReportContent)
     : [];
+  const reportFallbackContent = selectedReport
+    ? extractHealthReportDisplayContent(selectedReport.healthReportContent)
+    : null;
   const reportPrimaryContent =
-    reportRecommendations[0] || (selectedReport ? summarizeContent(selectedReport.healthReportContent, 96) : '');
+    reportRecommendations[0] ||
+    (reportFallbackContent
+      ? summarizeContent(reportFallbackContent, 96)
+      : '건강 분석 상세 내용이 아직 준비되지 않았어요.');
 
   return (
     <section className="w-full" aria-labelledby="home-health-report-heading">

--- a/src/pages/main/ui/sections/NoticeAndQuickLinksSection.tsx
+++ b/src/pages/main/ui/sections/NoticeAndQuickLinksSection.tsx
@@ -1,105 +1,61 @@
 import { Link } from 'react-router-dom';
 
-import type { MainAnnouncement } from '@/pages/main/model/types';
+import { NOTICES, type NoticeTag } from '@/pages/main/model/homeMock';
 import { QUICK_LINKS } from '@/pages/main/model/quickLinks';
-import { Skeleton } from '@/shared/ui';
 
-import { summarizeContent } from '../../model/formatters';
+const TAG_STYLES: Record<NoticeTag, string> = {
+  안내: 'bg-[#E8F5E9] text-[#2E7D32]',
+  긴급: 'bg-[#FFEBEE] text-[#C62828]',
+};
 
-interface NoticeAndQuickLinksSectionProps {
-  isLoading: boolean;
-  errorMessage: string | null;
-  announcements: MainAnnouncement[];
-}
-
-export function NoticeAndQuickLinksSection({
-  isLoading,
-  errorMessage,
-  announcements,
-}: NoticeAndQuickLinksSectionProps) {
+export function NoticeAndQuickLinksSection() {
   return (
     <section className="w-full" aria-labelledby="home-notice-quick-heading">
       <h2 id="home-notice-quick-heading" className="sr-only">
         공지사항 및 바로가기
       </h2>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] lg:gap-5">
-        <article className="rounded-[28px] border border-neutral-200 bg-white p-5 shadow-sm sm:p-6">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-[11px] font-semibold tracking-[0.16em] text-neutral-400">NOTICE</p>
-              <h3 className="mt-2 text-[22px] font-semibold text-neutral-950">공지사항</h3>
-            </div>
-            <Link
-              to="/community"
-              className="inline-flex h-10 items-center justify-center rounded-full border border-neutral-200 px-4 text-sm font-medium text-neutral-700 transition-colors hover:border-brand/40 hover:text-brand"
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:gap-5">
+        <article className="px-2 py-5 sm:px-2 sm:py-6">
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-[20px] font-bold text-neutral-900">공지사항</h3>
+            <button
+              type="button"
+              className="shrink-0 cursor-pointer text-2xl leading-none font-light text-neutral-400 transition-colors hover:text-neutral-600"
+              aria-label="공지사항 더보기"
             >
-              더 보기
-            </Link>
+              +
+            </button>
           </div>
 
-          {isLoading ? (
-            <div className="mt-5 space-y-3">
-              {Array.from({ length: 4 }).map((_, index) => (
-                <div key={index} className="rounded-[20px] border border-neutral-100 p-4">
-                  <Skeleton className="h-4 w-20 rounded-md" />
-                  <Skeleton className="mt-3 h-5 w-full rounded-md" />
-                  <Skeleton className="mt-2 h-4 w-5/6 rounded-md" />
-                </div>
-              ))}
-            </div>
-          ) : errorMessage ? (
-            <div className="mt-5 rounded-[20px] border border-red-100 bg-red-50/70 p-4">
-              <p className="text-sm leading-6 text-red-500">{errorMessage}</p>
-            </div>
-          ) : announcements.length > 0 ? (
-            <ul className="mt-5 space-y-3">
-              {announcements.slice(0, 4).map((announcement, index) => (
-                <li key={`${announcement.boardTitle}-${index}`}>
-                  <Link
-                    to="/community"
-                    className="block rounded-[20px] border border-neutral-100 p-4 transition-colors hover:border-brand/30 hover:bg-[#fffaf5]"
+          <ul className="mt-3 flex flex-col">
+            {NOTICES.map((notice) => (
+              <li key={notice.id}>
+                <button type="button" className="flex w-full items-center gap-2.5 py-2.5 text-left">
+                  <span
+                    className={`shrink-0 rounded-full px-2.5 py-1 text-[12px] font-semibold leading-none ${TAG_STYLES[notice.tag]}`}
                   >
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="inline-flex rounded-full bg-[#fff4ea] px-2.5 py-1 text-xs font-semibold text-[#c46f3e]">
-                        공지
-                      </span>
-                      <span className="text-xs text-neutral-400">조회 {announcement.viewCount}</span>
-                    </div>
-                    <p className="mt-3 line-clamp-1 text-[15px] font-semibold text-neutral-900">
-                      {announcement.boardTitle}
-                    </p>
-                    <p className="mt-2 text-sm leading-6 text-neutral-500">
-                      {summarizeContent(announcement.boardContent, 88)}
-                    </p>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <div className="mt-5 rounded-[20px] border border-dashed border-neutral-200 bg-neutral-50 p-4">
-              <p className="text-sm leading-7 text-neutral-500">
-                등록된 공지사항이 없어요. 새로운 소식이 올라오면 이곳에서 바로 확인할 수 있어요.
-              </p>
-            </div>
-          )}
+                    {notice.tag}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-sm text-neutral-800">{notice.title}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
         </article>
 
-        <article className="rounded-[28px] border border-neutral-200 bg-white p-5 shadow-sm sm:p-6">
-          <div>
-            <p className="text-[11px] font-semibold tracking-[0.16em] text-neutral-400">SHORTCUT</p>
-            <h3 className="mt-2 text-[22px] font-semibold text-neutral-950">바로가기</h3>
-          </div>
+        <article className="flex flex-col rounded-2xl px-5 py-5 sm:px-6 sm:py-6">
+          <h3 className="text-[20px] font-bold text-neutral-900">바로가기</h3>
 
-          <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <div className="mt-4 grid flex-1 content-center grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
             {QUICK_LINKS.map(({ id, to, label, Icon }) => (
               <Link
                 key={id}
                 to={to}
-                className="group flex min-h-40 flex-col items-center justify-center gap-3 rounded-[24px] border border-neutral-200 bg-[linear-gradient(180deg,#ffffff_0%,#fffaf5_100%)] px-3 py-4 transition-all hover:-translate-y-0.5 hover:border-brand/35 hover:shadow-[0_14px_30px_rgba(217,123,58,0.10)]"
+                className="flex aspect-square flex-col items-center justify-center gap-2.5 rounded-xl border border-neutral-200 bg-white px-2 py-3 transition-colors hover:border-neutral-300"
               >
-                <Icon className="h-20 w-20 transition-transform group-hover:scale-[1.03]" />
-                <span className="text-center text-sm font-semibold text-neutral-800">{label}</span>
+                <Icon className="h-20 w-20 sm:h-24 sm:w-24" />
+                <span className="text-center text-[14px] font-medium text-neutral-800">{label}</span>
               </Link>
             ))}
           </div>

--- a/src/pages/main/ui/sections/NoticeAndQuickLinksSection.tsx
+++ b/src/pages/main/ui/sections/NoticeAndQuickLinksSection.tsx
@@ -1,61 +1,105 @@
 import { Link } from 'react-router-dom';
 
-import { NOTICES, type NoticeTag } from '@/pages/main/model/homeMock';
+import type { MainAnnouncement } from '@/pages/main/model/types';
 import { QUICK_LINKS } from '@/pages/main/model/quickLinks';
+import { Skeleton } from '@/shared/ui';
 
-const TAG_STYLES: Record<NoticeTag, string> = {
-  안내: 'bg-[#E8F5E9] text-[#2E7D32]',
-  긴급: 'bg-[#FFEBEE] text-[#C62828]',
-};
+import { summarizeContent } from '../../model/formatters';
 
-export function NoticeAndQuickLinksSection() {
+interface NoticeAndQuickLinksSectionProps {
+  isLoading: boolean;
+  errorMessage: string | null;
+  announcements: MainAnnouncement[];
+}
+
+export function NoticeAndQuickLinksSection({
+  isLoading,
+  errorMessage,
+  announcements,
+}: NoticeAndQuickLinksSectionProps) {
   return (
     <section className="w-full" aria-labelledby="home-notice-quick-heading">
       <h2 id="home-notice-quick-heading" className="sr-only">
         공지사항 및 바로가기
       </h2>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:gap-5">
-        <article className="px-2 py-5 sm:px-2 sm:py-6">
-          <div className="flex items-center justify-between gap-2">
-            <h3 className="text-base font-bold text-[20px] text-neutral-900">공지사항</h3>
-            <button
-              type="button"
-              className="shrink-0 text-2xl leading-none font-light text-neutral-400 transition-colors hover:text-neutral-600 cursor-pointer"
-              aria-label="공지사항 더보기"
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] lg:gap-5">
+        <article className="rounded-[28px] border border-neutral-200 bg-white p-5 shadow-sm sm:p-6">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold tracking-[0.16em] text-neutral-400">NOTICE</p>
+              <h3 className="mt-2 text-[22px] font-semibold text-neutral-950">공지사항</h3>
+            </div>
+            <Link
+              to="/community"
+              className="inline-flex h-10 items-center justify-center rounded-full border border-neutral-200 px-4 text-sm font-medium text-neutral-700 transition-colors hover:border-brand/40 hover:text-brand"
             >
-              +
-            </button>
+              더 보기
+            </Link>
           </div>
 
-          <ul className="mt-3 flex flex-col">
-            {NOTICES.map((notice) => (
-              <li key={notice.id}>
-                <button type="button" className="flex w-full items-center gap-2.5 py-2.5 text-left">
-                  <span
-                    className={`shrink-0 rounded-full px-2.5 py-1 text-[12px] font-semibold leading-none ${TAG_STYLES[notice.tag]}`}
+          {isLoading ? (
+            <div className="mt-5 space-y-3">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="rounded-[20px] border border-neutral-100 p-4">
+                  <Skeleton className="h-4 w-20 rounded-md" />
+                  <Skeleton className="mt-3 h-5 w-full rounded-md" />
+                  <Skeleton className="mt-2 h-4 w-5/6 rounded-md" />
+                </div>
+              ))}
+            </div>
+          ) : errorMessage ? (
+            <div className="mt-5 rounded-[20px] border border-red-100 bg-red-50/70 p-4">
+              <p className="text-sm leading-6 text-red-500">{errorMessage}</p>
+            </div>
+          ) : announcements.length > 0 ? (
+            <ul className="mt-5 space-y-3">
+              {announcements.slice(0, 4).map((announcement, index) => (
+                <li key={`${announcement.boardTitle}-${index}`}>
+                  <Link
+                    to="/community"
+                    className="block rounded-[20px] border border-neutral-100 p-4 transition-colors hover:border-brand/30 hover:bg-[#fffaf5]"
                   >
-                    {notice.tag}
-                  </span>
-                  <span className="min-w-0 flex-1 truncate text-sm text-neutral-800">{notice.title}</span>
-                </button>
-              </li>
-            ))}
-          </ul>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="inline-flex rounded-full bg-[#fff4ea] px-2.5 py-1 text-xs font-semibold text-[#c46f3e]">
+                        공지
+                      </span>
+                      <span className="text-xs text-neutral-400">조회 {announcement.viewCount}</span>
+                    </div>
+                    <p className="mt-3 line-clamp-1 text-[15px] font-semibold text-neutral-900">
+                      {announcement.boardTitle}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-neutral-500">
+                      {summarizeContent(announcement.boardContent, 88)}
+                    </p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="mt-5 rounded-[20px] border border-dashed border-neutral-200 bg-neutral-50 p-4">
+              <p className="text-sm leading-7 text-neutral-500">
+                등록된 공지사항이 없어요. 새로운 소식이 올라오면 이곳에서 바로 확인할 수 있어요.
+              </p>
+            </div>
+          )}
         </article>
 
-        <article className="flex flex-col rounded-2xl px-5 py-5 sm:px-6 sm:py-6">
-          <h3 className="text-base font-bold text-[20px] text-neutral-900">바로가기</h3>
+        <article className="rounded-[28px] border border-neutral-200 bg-white p-5 shadow-sm sm:p-6">
+          <div>
+            <p className="text-[11px] font-semibold tracking-[0.16em] text-neutral-400">SHORTCUT</p>
+            <h3 className="mt-2 text-[22px] font-semibold text-neutral-950">바로가기</h3>
+          </div>
 
-          <div className="mt-4 grid flex-1 content-center grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
+          <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
             {QUICK_LINKS.map(({ id, to, label, Icon }) => (
               <Link
                 key={id}
                 to={to}
-                className="flex aspect-square flex-col items-center justify-center gap-2.5 rounded-xl border border-neutral-200 bg-white px-2 py-3 transition-colors hover:border-neutral-300"
+                className="group flex min-h-40 flex-col items-center justify-center gap-3 rounded-[24px] border border-neutral-200 bg-[linear-gradient(180deg,#ffffff_0%,#fffaf5_100%)] px-3 py-4 transition-all hover:-translate-y-0.5 hover:border-brand/35 hover:shadow-[0_14px_30px_rgba(217,123,58,0.10)]"
               >
-                <Icon className="h-20 w-20 sm:h-24 sm:w-24" />
-                <span className="text-center text-[14px] font-medium text-neutral-800">{label}</span>
+                <Icon className="h-20 w-20 transition-transform group-hover:scale-[1.03]" />
+                <span className="text-center text-sm font-semibold text-neutral-800">{label}</span>
               </Link>
             ))}
           </div>

--- a/src/shared/lib/react-query/queryKey.ts
+++ b/src/shared/lib/react-query/queryKey.ts
@@ -1,4 +1,7 @@
 export const queryKeys = {
+  main: {
+    home: () => ['main', 'home'] as const,
+  },
   boards: {
     list: (params?: { page?: number; size?: number }) =>
       ['boards', 'list', params?.page ?? 0, params?.size ?? 12] as const,


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

메인 홈 상단 영역을 메인 정보 조회 API 기반으로 연결
반려동물 등록 여부에 따라 홈 UI가 분기되도록 구현

- 반려동물 미등록 시 기존 홈 메인 UI 유지
- 반려동물 등록 시 선택형 프로필 카드 + 건강 레포트 UI 노출
- 선택된 반려동물 기준 최신 건강 레포트 노출
- healthReportContent JSON 파싱 후 recommendations 우선 노출
- 백엔드 응답 변경 대응
  - title / summary / content 순서로 레포트 노출
  - summary 중복 노출되지 않도록 수정
- 우측 프로필 카드 정보 구조 정리
  - 이름, 나이, 품종, 체중만 노출
  - 불필요한 PROFILE/종 구분 텍스트 제거
- 하단 반려동물 썸네일 크기 및 정렬 보정

<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #60 

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

<img width="2008" height="542" alt="image" src="https://github.com/user-attachments/assets/fb900af3-7c0c-4265-b3ee-9bac1a040d54" />

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.
