### PR TITLE
✨ Feat: 산책 지오펜스(울타리) 및 실시간 위치 추적 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     ]
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.3.0",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.6",

--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -1,11 +1,15 @@
 import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import { redirectToLogin, refreshAccessToken } from '@/shared/lib/auth/refreshSession';
 import { getAccessToken, getRefreshToken, isAccessTokenExpired } from '@/shared/lib/auth/token';
 import { Header } from '@/widgets/header';
 
 export function AppLayout() {
+  const location = useLocation();
+  // 산책 페이지는 헤더 없는 전체화면(지도) 레이아웃
+  const isFullBleed = location.pathname.startsWith('/walk');
+
   useEffect(() => {
     if (!getAccessToken() || !getRefreshToken() || !isAccessTokenExpired()) {
       return;
@@ -20,6 +24,16 @@ export function AppLayout() {
 
     void refreshSession();
   }, []);
+
+  if (isFullBleed) {
+    return (
+      <div className="flex min-h-screen flex-col bg-neutral-50">
+        <main className="flex-1">
+          <Outlet />
+        </main>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen flex-col bg-neutral-50">

--- a/src/features/walk-fence/api/fence.ts
+++ b/src/features/walk-fence/api/fence.ts
@@ -1,0 +1,50 @@
+import { apiClient } from '@/shared/api/axios';
+
+import type {
+  CreateFenceRequest,
+  FenceBoundariesResponse,
+  FenceBoundaryResponse,
+  FenceMessageResponse,
+  FenceStatusResponse,
+  ToggleFenceRequest,
+  UpdateFenceRangeRequest,
+} from '../model/types';
+
+/** 1. 울타리 생성 */
+export async function createFence(payload: CreateFenceRequest): Promise<FenceMessageResponse> {
+  const response = await apiClient.post<FenceMessageResponse>('/fence/range', payload);
+  return response.data;
+}
+
+/** 2. 특정 반려동물의 울타리 활성화 상태 조회 */
+export async function getFenceStatus(petId: number): Promise<FenceStatusResponse> {
+  const response = await apiClient.get<FenceStatusResponse>(`/fence/${petId}/status`);
+  return response.data;
+}
+
+/** 3. 울타리 ON/OFF 변경 */
+export async function toggleFence(fenceId: number, payload: ToggleFenceRequest): Promise<FenceMessageResponse> {
+  const response = await apiClient.patch<FenceMessageResponse>(`/fence/${fenceId}/toggle`, payload);
+  return response.data;
+}
+
+/** 4. 울타리 이름/중심/반경 수정 */
+export async function updateFenceRange(
+  fenceId: number,
+  payload: UpdateFenceRangeRequest,
+): Promise<FenceMessageResponse> {
+  const response = await apiClient.patch<FenceMessageResponse>(`/fence/${fenceId}/range`, payload);
+  return response.data;
+}
+
+/** 5. 지도에 표시할 단일 울타리 경계 조회 */
+export async function getFenceBoundary(fenceId: number): Promise<FenceBoundaryResponse> {
+  const response = await apiClient.get<FenceBoundaryResponse>(`/fence/${fenceId}/boundary`);
+  return response.data;
+}
+
+/** 6. 접근 가능한 모든 울타리 경계 목록 조회 */
+export async function getFenceBoundaries(): Promise<FenceBoundariesResponse> {
+  const response = await apiClient.get<FenceBoundariesResponse>('/fence/boundaries');
+  return response.data;
+}

--- a/src/features/walk-fence/index.ts
+++ b/src/features/walk-fence/index.ts
@@ -1,1 +1,25 @@
+export {
+  createFence,
+  getFenceBoundaries,
+  getFenceBoundary,
+  getFenceStatus,
+  toggleFence,
+  updateFenceRange,
+} from './api/fence';
+export { useCreateFence } from './model/useCreateFence';
+export { useFenceBoundaries } from './model/useFenceBoundaries';
+export { useFenceStatus } from './model/useFenceStatus';
+export { useToggleFence } from './model/useToggleFence';
+export { useUpdateFenceRange } from './model/useUpdateFenceRange';
 export { WalkMap } from './ui/WalkMap';
+export type {
+  CreateFenceRequest,
+  FenceBoundariesResponse,
+  FenceBoundary,
+  FenceBoundaryResponse,
+  FenceCenter,
+  FenceMessageResponse,
+  FenceStatusResponse,
+  ToggleFenceRequest,
+  UpdateFenceRangeRequest,
+} from './model/types';

--- a/src/features/walk-fence/index.ts
+++ b/src/features/walk-fence/index.ts
@@ -11,6 +11,7 @@ export { useFenceBoundaries } from './model/useFenceBoundaries';
 export { useFenceStatus } from './model/useFenceStatus';
 export { useToggleFence } from './model/useToggleFence';
 export { useUpdateFenceRange } from './model/useUpdateFenceRange';
+export { FenceControlPanel } from './ui/FenceControlPanel';
 export { WalkMap } from './ui/WalkMap';
 export type {
   CreateFenceRequest,

--- a/src/features/walk-fence/index.ts
+++ b/src/features/walk-fence/index.ts
@@ -1,0 +1,1 @@
+export { WalkMap } from './ui/WalkMap';

--- a/src/features/walk-fence/index.ts
+++ b/src/features/walk-fence/index.ts
@@ -21,6 +21,8 @@ export type {
   FenceCenter,
   FenceMessageResponse,
   FenceStatusResponse,
+  LiveLocationMessage, // 실시간 위치 업데이트 서버 메세지 전체 받기
+  LiveLocationPayload, // 실시간 위치 업데이트 서버 메세지 중 payload 부분
   ToggleFenceRequest,
   UpdateFenceRangeRequest,
 } from './model/types';

--- a/src/features/walk-fence/index.ts
+++ b/src/features/walk-fence/index.ts
@@ -9,6 +9,7 @@ export {
 export { useCreateFence } from './model/useCreateFence';
 export { useFenceBoundaries } from './model/useFenceBoundaries';
 export { useFenceStatus } from './model/useFenceStatus';
+export { useLiveLocation } from './model/useLiveLocation';
 export { useToggleFence } from './model/useToggleFence';
 export { useUpdateFenceRange } from './model/useUpdateFenceRange';
 export { FenceControlPanel } from './ui/FenceControlPanel';

--- a/src/features/walk-fence/model/types.ts
+++ b/src/features/walk-fence/model/types.ts
@@ -1,0 +1,67 @@
+// 울타리(지오펜스) REST API 요청/응답 타입
+
+/** 좌표 (위도/경도) */
+export interface FenceCenter {
+  latitude: number;
+  longitude: number;
+}
+
+/** 공통 메시지 응답 */
+export interface FenceMessageResponse {
+  message: string;
+}
+
+/** 1. 울타리 생성 — POST /fence/range */
+export interface CreateFenceRequest {
+  petId: number;
+  centerLatitude: number;
+  centerLongitude: number;
+  /** 반경(미터) */
+  radius: number;
+  fenceName: string;
+}
+
+/** 2. 울타리 상태 조회 — GET /fence/{petId}/status */
+export interface FenceStatusResponse {
+  message: string;
+  isActive: boolean;
+}
+
+/** 3. 울타리 ON/OFF — PATCH /fence/{fenceId}/toggle */
+export interface ToggleFenceRequest {
+  fenceIsActive: boolean;
+}
+
+/** 4. 울타리 범위 수정 — PATCH /fence/{fenceId}/range (모든 필드 선택) */
+export interface UpdateFenceRangeRequest {
+  centerLatitude?: number;
+  centerLongitude?: number;
+  fenceName?: string;
+  radius?: number;
+}
+
+/** 5. 울타리 경계 조회 — GET /fence/{fenceId}/boundary */
+export interface FenceBoundaryResponse {
+  message: string;
+  center: FenceCenter;
+  radius: number;
+  fenceId: number;
+}
+
+/** 6-1. 울타리 경계 목록의 단일 항목 */
+export interface FenceBoundary {
+  fenceId: number;
+  fenceName: string;
+  center: FenceCenter;
+  radius: number;
+  isActive: boolean;
+  petId: number;
+  petName: string;
+  petImageUrl: string;
+}
+
+/** 6. 울타리 경계 목록 조회 — GET /fence/boundaries */
+export interface FenceBoundariesResponse {
+  message: string;
+  boundaries: FenceBoundary[];
+}

--- a/src/features/walk-fence/model/types.ts
+++ b/src/features/walk-fence/model/types.ts
@@ -65,3 +65,24 @@ export interface FenceBoundariesResponse {
   message: string;
   boundaries: FenceBoundary[];
 }
+
+// 실시간 위치 업데이트 WebSocket 메시지 타입
+/** 실시간 위치 메시지의 payload (서버가 울타리 판정까지 해서 보냄) */
+export interface LiveLocationPayload {
+  petId: number;
+  latitude: number;
+  longitude: number;
+  measuredAt: string;
+  /** 울타리 안에 있는지 (서버 판정) */
+  insideFence: boolean;
+  /** 울타리 중심에서의 거리(미터) */
+  distanceMeter: number;
+  radius: number;
+  message: string;
+}
+
+/** WebSocket 수신 메시지 (payload가 한 겹 감싸져 있음) */
+export interface LiveLocationMessage {
+  type: string;
+  payload: LiveLocationPayload;
+}

--- a/src/features/walk-fence/model/useCreateFence.ts
+++ b/src/features/walk-fence/model/useCreateFence.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { createFence } from '../api/fence';
+import { queryKeys } from '@/shared/lib/react-query/queryKey';
+
+/** 울타리 생성 후 경계 목록 갱신 */
+export function useCreateFence() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createFence,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.fence.boundaries() });
+    },
+  });
+}

--- a/src/features/walk-fence/model/useFenceBoundaries.ts
+++ b/src/features/walk-fence/model/useFenceBoundaries.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getFenceBoundaries } from '../api/fence';
+import { queryKeys } from '@/shared/lib/react-query/queryKey';
+
+/** 접근 가능한 모든 울타리 경계 목록 조회 */
+export function useFenceBoundaries() {
+  return useQuery({
+    queryKey: queryKeys.fence.boundaries(),
+    queryFn: getFenceBoundaries,
+  });
+}

--- a/src/features/walk-fence/model/useFenceStatus.ts
+++ b/src/features/walk-fence/model/useFenceStatus.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getFenceStatus } from '../api/fence';
+import { queryKeys } from '@/shared/lib/react-query/queryKey';
+
+/** 특정 반려동물의 울타리 활성화 상태 조회 (petId 없으면 비활성) */
+export function useFenceStatus(petId: number | null) {
+  return useQuery({
+    queryKey: queryKeys.fence.status(petId ?? 0),
+    queryFn: () => getFenceStatus(petId as number),
+    enabled: petId != null,
+  });
+}

--- a/src/features/walk-fence/model/useLiveLocation.ts
+++ b/src/features/walk-fence/model/useLiveLocation.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+import { createStompClient } from '@/shared/lib/socket/stompClient';
+
+import type { LiveLocationMessage, LiveLocationPayload } from './types';
+
+/** 특정 펫의 실시간 위치를 구독 (petId 없으면 연결 안 함) */
+export function useLiveLocation(petId: number | null) {
+  const [location, setLocation] = useState<LiveLocationPayload | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+
+  // petId가 바뀌면 이전 펫 위치를 초기화 (렌더 중 조정 — effect 내 setState 회피)
+  const [trackedPetId, setTrackedPetId] = useState(petId);
+  if (petId !== trackedPetId) {
+    setTrackedPetId(petId);
+    setLocation(null);
+    setIsConnected(false);
+  }
+
+  useEffect(() => {
+    if (petId == null) return;
+
+    const client = createStompClient();
+
+    // 연결 성공 시 구독 시작
+    client.onConnect = () => {
+      setIsConnected(true);
+      client.subscribe(`/sub/fence/location/${petId}`, (frame) => {
+        try {
+          const message = JSON.parse(frame.body) as LiveLocationMessage;
+          setLocation(message.payload); // 감싸진 payload만 꺼내 저장
+        } catch {
+          // JSON 파싱 실패는 무시
+        }
+      });
+    };
+
+    // 연결 끊기면 표시
+    client.onWebSocketClose = () => {
+      setIsConnected(false);
+    };
+
+    client.activate(); // 연결 시작
+
+    // 언마운트 / petId 변경 시 연결 해제
+    return () => {
+      void client.deactivate();
+    };
+  }, [petId]);
+
+  return { location, isConnected };
+}

--- a/src/features/walk-fence/model/useToggleFence.ts
+++ b/src/features/walk-fence/model/useToggleFence.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { toggleFence } from '../api/fence';
+import type { ToggleFenceRequest } from './types';
+import { queryKeys } from '@/shared/lib/react-query/queryKey';
+
+interface ToggleFenceVariables {
+  fenceId: number;
+  payload: ToggleFenceRequest;
+}
+
+/** 울타리 ON/OFF 변경 후 경계 목록 갱신 */
+export function useToggleFence() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ fenceId, payload }: ToggleFenceVariables) => toggleFence(fenceId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.fence.boundaries() });
+    },
+  });
+}

--- a/src/features/walk-fence/model/useUpdateFenceRange.ts
+++ b/src/features/walk-fence/model/useUpdateFenceRange.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateFenceRange } from '../api/fence';
+import type { UpdateFenceRangeRequest } from './types';
+import { queryKeys } from '@/shared/lib/react-query/queryKey';
+
+interface UpdateFenceRangeVariables {
+  fenceId: number;
+  payload: UpdateFenceRangeRequest;
+}
+
+/** 울타리 이름/중심/반경 수정 후 관련 쿼리 갱신 */
+export function useUpdateFenceRange() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ fenceId, payload }: UpdateFenceRangeVariables) => updateFenceRange(fenceId, payload),
+    onSuccess: (_data, { fenceId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.fence.boundaries() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.fence.boundary(fenceId) });
+    },
+  });
+}

--- a/src/features/walk-fence/ui/FenceControlPanel.tsx
+++ b/src/features/walk-fence/ui/FenceControlPanel.tsx
@@ -42,8 +42,8 @@ export function FenceControlPanel({
   const selectedPet = pets.find((pet) => pet.petId === selectedPetId) ?? null;
 
   return (
-    <aside className="flex flex-col gap-5 rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
-      <h2 className="text-base font-semibold text-neutral-900">울타리 설정</h2>
+    <div className="flex flex-col gap-5 p-5">
+      <h2 className="text-sm font-semibold text-neutral-900">울타리 설정</h2>
 
       {/* 펫 선택 */}
       <div>
@@ -87,20 +87,18 @@ export function FenceControlPanel({
                 : ' (아직 미지정)'}
           </p>
 
-          {/* 이름 (생성 모드에서만) */}
-          {!existingFence && (
-            <label className="flex flex-col gap-1.5">
-              <span className="text-sm font-medium text-neutral-700">울타리 이름</span>
-              <input
-                type="text"
-                value={fenceName}
-                maxLength={255}
-                onChange={(event) => onFenceNameChange(event.target.value)}
-                placeholder="예: 집 주변 울타리"
-                className="rounded-lg border border-neutral-300 px-3 py-2 text-sm outline-none focus:border-brand"
-              />
-            </label>
-          )}
+          {/* 이름 (생성/수정 공통) */}
+          <label className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium text-neutral-700">울타리 이름</span>
+            <input
+              type="text"
+              value={fenceName}
+              maxLength={255}
+              onChange={(event) => onFenceNameChange(event.target.value)}
+              placeholder="예: 집 주변 울타리"
+              className="rounded-lg border border-neutral-300 px-3 py-2 text-sm outline-none focus:border-brand"
+            />
+          </label>
 
           {/* 반경 */}
           <label className="flex flex-col gap-1.5">
@@ -125,19 +123,20 @@ export function FenceControlPanel({
                 </span>
                 <button
                   type="button"
+                  role="switch"
                   onClick={onToggle}
                   disabled={isSubmitting}
                   className={[
-                    'relative h-6 w-11 rounded-full transition-colors disabled:opacity-50',
+                    'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50',
                     existingFence.isActive ? 'bg-brand' : 'bg-neutral-300',
                   ].join(' ')}
-                  aria-pressed={existingFence.isActive}
+                  aria-checked={existingFence.isActive}
                   aria-label="울타리 켜기/끄기"
                 >
                   <span
                     className={[
-                      'absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform',
-                      existingFence.isActive ? 'translate-x-5' : 'translate-x-0.5',
+                      'inline-block h-5 w-5 rounded-full bg-white shadow transition-transform',
+                      existingFence.isActive ? 'translate-x-[22px]' : 'translate-x-0.5',
                     ].join(' ')}
                   />
                 </button>
@@ -163,6 +162,6 @@ export function FenceControlPanel({
           )}
         </>
       )}
-    </aside>
+    </div>
   );
 }

--- a/src/features/walk-fence/ui/FenceControlPanel.tsx
+++ b/src/features/walk-fence/ui/FenceControlPanel.tsx
@@ -144,7 +144,7 @@ export function FenceControlPanel({
               <button
                 type="button"
                 onClick={onUpdate}
-                disabled={isSubmitting}
+                disabled={isSubmitting || fenceName.trim().length === 0}
                 className="inline-flex min-h-11 items-center justify-center rounded-xl bg-brand px-5 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
               >
                 울타리 수정 저장

--- a/src/features/walk-fence/ui/FenceControlPanel.tsx
+++ b/src/features/walk-fence/ui/FenceControlPanel.tsx
@@ -1,0 +1,168 @@
+import type { PetListItem } from '@/features/auth';
+
+import type { FenceBoundary } from '../model/types';
+
+interface DraftCenter {
+  lat: number;
+  lng: number;
+}
+
+interface FenceControlPanelProps {
+  pets: PetListItem[];
+  selectedPetId: number | null;
+  onSelectPet: (petId: number) => void;
+  /** 선택한 펫의 기존 울타리 (없으면 null → 생성 모드) */
+  existingFence: FenceBoundary | null;
+  draftCenter: DraftCenter | null;
+  radius: number;
+  onRadiusChange: (radius: number) => void;
+  fenceName: string;
+  onFenceNameChange: (name: string) => void;
+  onCreate: () => void;
+  onUpdate: () => void;
+  onToggle: () => void;
+  isSubmitting: boolean;
+}
+
+export function FenceControlPanel({
+  pets,
+  selectedPetId,
+  onSelectPet,
+  existingFence,
+  draftCenter,
+  radius,
+  onRadiusChange,
+  fenceName,
+  onFenceNameChange,
+  onCreate,
+  onUpdate,
+  onToggle,
+  isSubmitting,
+}: FenceControlPanelProps) {
+  const selectedPet = pets.find((pet) => pet.petId === selectedPetId) ?? null;
+
+  return (
+    <aside className="flex flex-col gap-5 rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
+      <h2 className="text-base font-semibold text-neutral-900">울타리 설정</h2>
+
+      {/* 펫 선택 */}
+      <div>
+        <p className="mb-2 text-sm font-medium text-neutral-700">반려동물 선택</p>
+        {pets.length === 0 ? (
+          <p className="text-sm text-neutral-400">등록된 반려동물이 없어요.</p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {pets.map((pet) => {
+              const isActive = pet.petId === selectedPetId;
+              return (
+                <button
+                  key={pet.petId}
+                  type="button"
+                  onClick={() => onSelectPet(pet.petId)}
+                  className={[
+                    'rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'border-brand bg-brand text-brand-foreground'
+                      : 'border-neutral-300 text-neutral-700 hover:bg-neutral-50',
+                  ].join(' ')}
+                  aria-pressed={isActive}
+                >
+                  {pet.petName}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {selectedPet && (
+        <>
+          {/* 안내 */}
+          <p className="rounded-lg bg-neutral-50 px-3 py-2 text-xs leading-5 text-neutral-500">
+            지도를 클릭해 울타리 중심을 {existingFence ? '옮길' : '지정할'} 수 있어요.
+            {draftCenter
+              ? ` 현재: ${draftCenter.lat.toFixed(5)}, ${draftCenter.lng.toFixed(5)}`
+              : existingFence
+                ? ' (지금은 기존 중심 유지)'
+                : ' (아직 미지정)'}
+          </p>
+
+          {/* 이름 (생성 모드에서만) */}
+          {!existingFence && (
+            <label className="flex flex-col gap-1.5">
+              <span className="text-sm font-medium text-neutral-700">울타리 이름</span>
+              <input
+                type="text"
+                value={fenceName}
+                maxLength={255}
+                onChange={(event) => onFenceNameChange(event.target.value)}
+                placeholder="예: 집 주변 울타리"
+                className="rounded-lg border border-neutral-300 px-3 py-2 text-sm outline-none focus:border-brand"
+              />
+            </label>
+          )}
+
+          {/* 반경 */}
+          <label className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium text-neutral-700">반경: {radius}m</span>
+            <input
+              type="range"
+              min={50}
+              max={2000}
+              step={50}
+              value={radius}
+              onChange={(event) => onRadiusChange(Number(event.target.value))}
+              className="accent-brand"
+            />
+          </label>
+
+          {/* 기존 울타리: 상태 + 수정 / 없으면: 생성 */}
+          {existingFence ? (
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between rounded-lg border border-neutral-200 px-3 py-2.5">
+                <span className="text-sm font-medium text-neutral-700">
+                  울타리 {existingFence.isActive ? '켜짐' : '꺼짐'}
+                </span>
+                <button
+                  type="button"
+                  onClick={onToggle}
+                  disabled={isSubmitting}
+                  className={[
+                    'relative h-6 w-11 rounded-full transition-colors disabled:opacity-50',
+                    existingFence.isActive ? 'bg-brand' : 'bg-neutral-300',
+                  ].join(' ')}
+                  aria-pressed={existingFence.isActive}
+                  aria-label="울타리 켜기/끄기"
+                >
+                  <span
+                    className={[
+                      'absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform',
+                      existingFence.isActive ? 'translate-x-5' : 'translate-x-0.5',
+                    ].join(' ')}
+                  />
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={onUpdate}
+                disabled={isSubmitting}
+                className="inline-flex min-h-11 items-center justify-center rounded-xl bg-brand px-5 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                울타리 수정 저장
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={onCreate}
+              disabled={isSubmitting || !draftCenter || fenceName.trim().length === 0}
+              className="inline-flex min-h-11 items-center justify-center rounded-xl bg-brand px-5 text-sm font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              울타리 생성
+            </button>
+          )}
+        </>
+      )}
+    </aside>
+  );
+}

--- a/src/features/walk-fence/ui/WalkMap.tsx
+++ b/src/features/walk-fence/ui/WalkMap.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { loadNaverMap } from '@/shared/lib/naver-map/loadNaverMap';
+
+// 지도 기본 중심 좌표 (서울시청) — 나중에 펫 위치로 교체
+const DEFAULT_CENTER = { lat: 37.5666103, lng: 126.9783882 };
+
+export function WalkMap() {
+  // 지도를 그릴 빈 div 참조
+  const mapElementRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // useEffect 내에서 loadNaverMap() 호출 → new naver.maps.Map() 생성
+    let map: naver.maps.Map | null = null;
+    let canceled = false;
+
+    loadNaverMap()
+      .then(() => {
+        // 스크립트 로드 사이에 언마운트됐거나 div가 없으면 중단
+        if (canceled || !mapElementRef.current) return;
+
+        map = new naver.maps.Map(mapElementRef.current, {
+          center: new naver.maps.LatLng(DEFAULT_CENTER.lat, DEFAULT_CENTER.lng),
+          zoom: 15,
+        });
+      })
+      .catch((e: unknown) => {
+        if (!canceled) {
+          setError(e instanceof Error ? e.message : '지도를 불러오지 못했습니다.');
+        }
+      });
+
+    // 언마운트 시 정리
+    return () => {
+      // canceled 플래그 + map.destroy()로 페이지 나갈 때 깔끔하게 정리
+      canceled = true;
+      map?.destroy();
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="flex h-full w-full items-center justify-center rounded-2xl bg-red-50 p-6 text-sm text-red-500">
+        {error}
+      </div>
+    );
+  }
+
+  // 지도는 부모에 높이가 있어야 보여요 → 여기서 높이 지정
+  return <div ref={mapElementRef} className="h-[500px] w-full overflow-hidden rounded-2xl" />;
+}

--- a/src/features/walk-fence/ui/WalkMap.tsx
+++ b/src/features/walk-fence/ui/WalkMap.tsx
@@ -2,32 +2,59 @@ import { useEffect, useRef, useState } from 'react';
 
 import { loadNaverMap } from '@/shared/lib/naver-map/loadNaverMap';
 
-import { useFenceBoundaries } from '../model/useFenceBoundaries';
+import type { FenceBoundary } from '../model/types';
 
-const DEFAULT_CENTER = { lat: 37.5666103, lng: 126.9783882 };
+interface DraftCenter {
+  lat: number;
+  lng: number;
+}
 
-export function WalkMap() {
-  // useRef로 지도 요소와 인스턴스, 그려둔 원들 보관
-  // 리렌더돼도 같은 지도 객체를 유지하고 다시 그릴 때 이전 원을 지우기
+interface WalkMapProps {
+  /** 지도에 그릴 기존 울타리 목록 */
+  boundaries: FenceBoundary[];
+  /** 생성/수정 미리보기용 중심 (없으면 미리보기 원 숨김) */
+  draftCenter: DraftCenter | null;
+  /** 미리보기 원 반경(미터) */
+  draftRadius: number;
+  /** 지도 클릭 시 좌표 콜백 */
+  onMapClick: (lat: number, lng: number) => void;
+}
+
+const DEFAULT_CENTER = { lat: 37.5796, lng: 126.977 }; // 경복궁
+
+export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick }: WalkMapProps) {
   const mapElementRef = useRef<HTMLDivElement>(null);
-  const mapInstanceRef = useRef<naver.maps.Map | null>(null); // 생성된 지도 보관
-  const circlesRef = useRef<naver.maps.Circle[]>([]); // 그려둔 원들 보관(나중에 지우려고)
+  const mapInstanceRef = useRef<naver.maps.Map | null>(null);
+  const circlesRef = useRef<naver.maps.Circle[]>([]); // 기존 울타리 원들
+  const draftCircleRef = useRef<naver.maps.Circle | null>(null); // 미리보기 원
+  const onMapClickRef = useRef(onMapClick); // 항상 최신 콜백 보관
   const [isMapReady, setIsMapReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { data } = useFenceBoundaries();
+  // 리스너를 다시 달지 않고도 최신 onMapClick을 부르도록 ref만 갱신
+  useEffect(() => {
+    onMapClickRef.current = onMapClick;
+  }, [onMapClick]);
 
-  // 1. 지도 생성 (최초 1회)
+  // 1. 지도 생성 + 클릭 리스너 (최초 1회)
   useEffect(() => {
     let canceled = false;
 
     loadNaverMap()
       .then(() => {
         if (canceled || !mapElementRef.current) return;
-        mapInstanceRef.current = new naver.maps.Map(mapElementRef.current, {
+
+        const map = new naver.maps.Map(mapElementRef.current, {
           center: new naver.maps.LatLng(DEFAULT_CENTER.lat, DEFAULT_CENTER.lng),
           zoom: 15,
         });
+
+        // 지도를 클릭하면 그 좌표를 콜백으로 올려보냄
+        map.addListener('click', (event) => {
+          onMapClickRef.current(event.coord.lat(), event.coord.lng());
+        });
+
+        mapInstanceRef.current = map;
         setIsMapReady(true);
       })
       .catch((e: unknown) => {
@@ -41,19 +68,15 @@ export function WalkMap() {
     };
   }, []);
 
-  // 2. 울타리 원 그리기 (지도 준비됨 + 데이터 들어옴/바뀜)
-  // 울타리 데이터는 나중에 도착하고 바뀔 수 있기 때문에
-  // → [isMapReady, data] (데이터 올 때마다 다시 그림)
+  // 2. 기존 울타리 원 그리기 (데이터 바뀔 때마다)
   useEffect(() => {
     const map = mapInstanceRef.current;
-    if (!isMapReady || !map || !data) return;
+    if (!isMapReady || !map) return;
 
-    // 이전에 그린 원 모두 제거
     circlesRef.current.forEach((circle) => circle.setMap(null));
     circlesRef.current = [];
 
-    // 새로 그리기
-    data.boundaries.forEach((fence) => {
+    boundaries.forEach((fence) => {
       const circle = new naver.maps.Circle({
         map,
         center: new naver.maps.LatLng(fence.center.latitude, fence.center.longitude),
@@ -65,17 +88,45 @@ export function WalkMap() {
       });
       circlesRef.current.push(circle);
     });
+  }, [isMapReady, boundaries]);
 
-    // 첫 울타리로 지도 중심 이동
-    const first = data.boundaries[0];
-    if (first) {
-      map.setCenter(new naver.maps.LatLng(first.center.latitude, first.center.longitude));
+  // 3. 미리보기(점선) 원 그리기/갱신
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!isMapReady || !map) return;
+
+    // 중심이 없으면 미리보기 원 제거
+    if (!draftCenter) {
+      draftCircleRef.current?.setMap(null);
+      draftCircleRef.current = null;
+      return;
     }
-  }, [isMapReady, data]);
+
+    const center = new naver.maps.LatLng(draftCenter.lat, draftCenter.lng);
+
+    if (draftCircleRef.current) {
+      // 이미 있으면 위치/반경만 갱신
+      draftCircleRef.current.setCenter(center);
+      draftCircleRef.current.setRadius(draftRadius);
+    } else {
+      draftCircleRef.current = new naver.maps.Circle({
+        map,
+        center,
+        radius: draftRadius,
+        strokeColor: '#f59e0b',
+        strokeWeight: 2,
+        strokeStyle: 'shortdash',
+        fillColor: '#f59e0b',
+        fillOpacity: 0.12,
+      });
+    }
+
+    map.setCenter(center);
+  }, [isMapReady, draftCenter, draftRadius]);
 
   if (error) {
     return (
-      <div className="flex h-full w-full items-center justify-center rounded-2xl bg-red-50 p-6 text-sm text-red-500">
+      <div className="flex h-[500px] w-full items-center justify-center rounded-2xl bg-red-50 p-6 text-sm text-red-500">
         {error}
       </div>
     );

--- a/src/features/walk-fence/ui/WalkMap.tsx
+++ b/src/features/walk-fence/ui/WalkMap.tsx
@@ -22,10 +22,21 @@ interface WalkMapProps {
 
 const DEFAULT_CENTER = { lat: 37.5796, lng: 126.977 }; // 경복궁
 
+// HTML 마커에 펫 이름을 넣기 전 간단한 이스케이프 (XSS 방지)
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function petLabelContent(name: string, isActive: boolean): string {
+  const color = isActive ? '#16a34a' : '#6b7280';
+  return `<div style="transform:translate(-50%,-50%);white-space:nowrap;background:#fff;border:1px solid ${color};border-radius:9999px;padding:2px 8px;font-size:12px;font-weight:600;color:${color};box-shadow:0 1px 2px rgba(0,0,0,.12)">${escapeHtml(name)}</div>`;
+}
+
 export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick }: WalkMapProps) {
   const mapElementRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<naver.maps.Map | null>(null);
   const circlesRef = useRef<naver.maps.Circle[]>([]); // 기존 울타리 원들
+  const markersRef = useRef<naver.maps.Marker[]>([]); // 펫 이름 라벨들
   const draftCircleRef = useRef<naver.maps.Circle | null>(null); // 미리보기 원
   const onMapClickRef = useRef(onMapClick); // 항상 최신 콜백 보관
   const [isMapReady, setIsMapReady] = useState(false);
@@ -68,18 +79,23 @@ export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick }: Wa
     };
   }, []);
 
-  // 2. 기존 울타리 원 그리기 (데이터 바뀔 때마다)
+  // 2. 기존 울타리 원 + 펫 이름 라벨 그리기 (데이터 바뀔 때마다)
   useEffect(() => {
     const map = mapInstanceRef.current;
     if (!isMapReady || !map) return;
 
+    // 이전 원/라벨 제거
     circlesRef.current.forEach((circle) => circle.setMap(null));
     circlesRef.current = [];
+    markersRef.current.forEach((marker) => marker.setMap(null));
+    markersRef.current = [];
 
     boundaries.forEach((fence) => {
+      const center = new naver.maps.LatLng(fence.center.latitude, fence.center.longitude);
+
       const circle = new naver.maps.Circle({
         map,
-        center: new naver.maps.LatLng(fence.center.latitude, fence.center.longitude),
+        center,
         radius: fence.radius,
         strokeColor: fence.isActive ? '#22c55e' : '#9ca3af', // 활성=초록, 비활성=회색
         strokeWeight: 2,
@@ -87,6 +103,17 @@ export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick }: Wa
         fillOpacity: 0.15,
       });
       circlesRef.current.push(circle);
+
+      // 울타리 중심에 펫 이름 라벨
+      const marker = new naver.maps.Marker({
+        map,
+        position: center,
+        icon: {
+          content: petLabelContent(fence.petName, fence.isActive),
+          anchor: new naver.maps.Point(0, 0),
+        },
+      });
+      markersRef.current.push(marker);
     });
   }, [isMapReady, boundaries]);
 
@@ -126,11 +153,9 @@ export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick }: Wa
 
   if (error) {
     return (
-      <div className="flex h-[500px] w-full items-center justify-center rounded-2xl bg-red-50 p-6 text-sm text-red-500">
-        {error}
-      </div>
+      <div className="flex h-full w-full items-center justify-center bg-red-50 p-6 text-sm text-red-500">{error}</div>
     );
   }
 
-  return <div ref={mapElementRef} className="h-[500px] w-full overflow-hidden rounded-2xl" />;
+  return <div ref={mapElementRef} className="h-full w-full" />;
 }

--- a/src/features/walk-fence/ui/WalkMap.tsx
+++ b/src/features/walk-fence/ui/WalkMap.tsx
@@ -2,42 +2,76 @@ import { useEffect, useRef, useState } from 'react';
 
 import { loadNaverMap } from '@/shared/lib/naver-map/loadNaverMap';
 
-// 지도 기본 중심 좌표 (서울시청) — 나중에 펫 위치로 교체
+import { useFenceBoundaries } from '../model/useFenceBoundaries';
+
 const DEFAULT_CENTER = { lat: 37.5666103, lng: 126.9783882 };
 
 export function WalkMap() {
-  // 지도를 그릴 빈 div 참조
+  // useRef로 지도 요소와 인스턴스, 그려둔 원들 보관
+  // 리렌더돼도 같은 지도 객체를 유지하고 다시 그릴 때 이전 원을 지우기
   const mapElementRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<naver.maps.Map | null>(null); // 생성된 지도 보관
+  const circlesRef = useRef<naver.maps.Circle[]>([]); // 그려둔 원들 보관(나중에 지우려고)
+  const [isMapReady, setIsMapReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const { data } = useFenceBoundaries();
+
+  // 1. 지도 생성 (최초 1회)
   useEffect(() => {
-    // useEffect 내에서 loadNaverMap() 호출 → new naver.maps.Map() 생성
-    let map: naver.maps.Map | null = null;
     let canceled = false;
 
     loadNaverMap()
       .then(() => {
-        // 스크립트 로드 사이에 언마운트됐거나 div가 없으면 중단
         if (canceled || !mapElementRef.current) return;
-
-        map = new naver.maps.Map(mapElementRef.current, {
+        mapInstanceRef.current = new naver.maps.Map(mapElementRef.current, {
           center: new naver.maps.LatLng(DEFAULT_CENTER.lat, DEFAULT_CENTER.lng),
           zoom: 15,
         });
+        setIsMapReady(true);
       })
       .catch((e: unknown) => {
-        if (!canceled) {
-          setError(e instanceof Error ? e.message : '지도를 불러오지 못했습니다.');
-        }
+        if (!canceled) setError(e instanceof Error ? e.message : '지도를 불러오지 못했습니다.');
       });
 
-    // 언마운트 시 정리
     return () => {
-      // canceled 플래그 + map.destroy()로 페이지 나갈 때 깔끔하게 정리
       canceled = true;
-      map?.destroy();
+      mapInstanceRef.current?.destroy();
+      mapInstanceRef.current = null;
     };
   }, []);
+
+  // 2. 울타리 원 그리기 (지도 준비됨 + 데이터 들어옴/바뀜)
+  // 울타리 데이터는 나중에 도착하고 바뀔 수 있기 때문에
+  // → [isMapReady, data] (데이터 올 때마다 다시 그림)
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!isMapReady || !map || !data) return;
+
+    // 이전에 그린 원 모두 제거
+    circlesRef.current.forEach((circle) => circle.setMap(null));
+    circlesRef.current = [];
+
+    // 새로 그리기
+    data.boundaries.forEach((fence) => {
+      const circle = new naver.maps.Circle({
+        map,
+        center: new naver.maps.LatLng(fence.center.latitude, fence.center.longitude),
+        radius: fence.radius,
+        strokeColor: fence.isActive ? '#22c55e' : '#9ca3af', // 활성=초록, 비활성=회색
+        strokeWeight: 2,
+        fillColor: fence.isActive ? '#22c55e' : '#9ca3af',
+        fillOpacity: 0.15,
+      });
+      circlesRef.current.push(circle);
+    });
+
+    // 첫 울타리로 지도 중심 이동
+    const first = data.boundaries[0];
+    if (first) {
+      map.setCenter(new naver.maps.LatLng(first.center.latitude, first.center.longitude));
+    }
+  }, [isMapReady, data]);
 
   if (error) {
     return (
@@ -47,6 +81,5 @@ export function WalkMap() {
     );
   }
 
-  // 지도는 부모에 높이가 있어야 보여요 → 여기서 높이 지정
   return <div ref={mapElementRef} className="h-[500px] w-full overflow-hidden rounded-2xl" />;
 }

--- a/src/features/walk-fence/ui/WalkMap.tsx
+++ b/src/features/walk-fence/ui/WalkMap.tsx
@@ -156,9 +156,14 @@ export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick, live
         fillOpacity: 0.12,
       });
     }
-
-    map.setCenter(center);
   }, [isMapReady, draftCenter, draftRadius]);
+
+  // 3-1. 지도 중심 이동은 draftCenter가 바뀔 때만 (반경 조절 시 스냅 방지)
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!isMapReady || !map || !draftCenter) return;
+    map.setCenter(new naver.maps.LatLng(draftCenter.lat, draftCenter.lng));
+  }, [isMapReady, draftCenter]);
 
   // 4. 실시간 펫 위치 마커 (위치 올 때마다 갱신)
   useEffect(() => {

--- a/src/features/walk-fence/ui/WalkMap.tsx
+++ b/src/features/walk-fence/ui/WalkMap.tsx
@@ -18,6 +18,8 @@ interface WalkMapProps {
   draftRadius: number;
   /** 지도 클릭 시 좌표 콜백 */
   onMapClick: (lat: number, lng: number) => void;
+  /** 실시간 펫 위치 (없으면 마커 숨김) */
+  livePosition: { lat: number; lng: number; insideFence: boolean } | null;
 }
 
 const DEFAULT_CENTER = { lat: 37.5796, lng: 126.977 }; // 경복궁
@@ -32,12 +34,19 @@ function petLabelContent(name: string, isActive: boolean): string {
   return `<div style="transform:translate(-50%,-50%);white-space:nowrap;background:#fff;border:1px solid ${color};border-radius:9999px;padding:2px 8px;font-size:12px;font-weight:600;color:${color};box-shadow:0 1px 2px rgba(0,0,0,.12)">${escapeHtml(name)}</div>`;
 }
 
-export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick }: WalkMapProps) {
+// 실시간 위치 점 마커 (울타리 안=초록, 밖=빨강)
+function liveMarkerContent(insideFence: boolean): string {
+  const color = insideFence ? '#22c55e' : '#ef4444';
+  return `<div style="transform:translate(-50%,-50%);width:16px;height:16px;border-radius:9999px;background:${color};border:3px solid #fff;box-shadow:0 0 0 5px ${color}33"></div>`;
+}
+
+export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick, livePosition }: WalkMapProps) {
   const mapElementRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<naver.maps.Map | null>(null);
   const circlesRef = useRef<naver.maps.Circle[]>([]); // 기존 울타리 원들
   const markersRef = useRef<naver.maps.Marker[]>([]); // 펫 이름 라벨들
   const draftCircleRef = useRef<naver.maps.Circle | null>(null); // 미리보기 원
+  const liveMarkerRef = useRef<naver.maps.Marker | null>(null); // 실시간 위치 마커
   const onMapClickRef = useRef(onMapClick); // 항상 최신 콜백 보관
   const [isMapReady, setIsMapReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -150,6 +159,27 @@ export function WalkMap({ boundaries, draftCenter, draftRadius, onMapClick }: Wa
 
     map.setCenter(center);
   }, [isMapReady, draftCenter, draftRadius]);
+
+  // 4. 실시간 펫 위치 마커 (위치 올 때마다 갱신)
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!isMapReady || !map) return;
+
+    // 이전 마커 제거 후 다시 그림 (마커 1개라 부담 없음)
+    liveMarkerRef.current?.setMap(null);
+    liveMarkerRef.current = null;
+
+    if (!livePosition) return;
+
+    liveMarkerRef.current = new naver.maps.Marker({
+      map,
+      position: new naver.maps.LatLng(livePosition.lat, livePosition.lng),
+      icon: {
+        content: liveMarkerContent(livePosition.insideFence),
+        anchor: new naver.maps.Point(0, 0),
+      },
+    });
+  }, [isMapReady, livePosition]);
 
   if (error) {
     return (

--- a/src/pages/walk/WalkPage.tsx
+++ b/src/pages/walk/WalkPage.tsx
@@ -83,14 +83,15 @@ export function WalkPage() {
   };
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-6">
-      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-        <WalkMap
-          boundaries={boundaries}
-          draftCenter={draftCenter}
-          draftRadius={radius}
-          onMapClick={(lat, lng) => setDraftCenter({ lat, lng })}
-        />
+    // 헤더(h-14) 아래로 전체 폭을 채우는 네이버 지도 스타일 레이아웃
+    // (main의 max-w-5xl·padding을 벗어나기 위해 full-bleed 처리)
+    <div className="relative left-1/2 -my-6 flex h-[calc(100vh-3.5rem)] w-screen -translate-x-1/2 overflow-hidden bg-white">
+      {/* 왼쪽 사이드바 — 울타리 설정 (추후 산책 활동 섹션 추가 예정) */}
+      <aside className="flex w-[380px] shrink-0 flex-col overflow-y-auto border-r border-neutral-200 bg-white">
+        <div className="border-b border-neutral-200 px-5 py-4">
+          <h1 className="text-lg font-bold text-neutral-900">산책</h1>
+          <p className="mt-0.5 text-xs text-neutral-500">반려동물 안전 울타리를 설정하세요.</p>
+        </div>
         <FenceControlPanel
           pets={pets}
           selectedPetId={selectedPetId}
@@ -105,6 +106,16 @@ export function WalkPage() {
           onUpdate={handleUpdate}
           onToggle={handleToggle}
           isSubmitting={isSubmitting}
+        />
+      </aside>
+
+      {/* 오른쪽 지도 영역 */}
+      <div className="relative flex-1">
+        <WalkMap
+          boundaries={boundaries}
+          draftCenter={draftCenter}
+          draftRadius={radius}
+          onMapClick={(lat, lng) => setDraftCenter({ lat, lng })}
         />
       </div>
     </div>

--- a/src/pages/walk/WalkPage.tsx
+++ b/src/pages/walk/WalkPage.tsx
@@ -1,3 +1,9 @@
+import { WalkMap } from '@/features/walk-fence';
+
 export function WalkPage() {
-  return <div className="p-6 text-center text-neutral-600">산책 (뼈대)</div>;
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-6">
+      <WalkMap />
+    </div>
+  );
 }

--- a/src/pages/walk/WalkPage.tsx
+++ b/src/pages/walk/WalkPage.tsx
@@ -10,6 +10,8 @@ import {
   useUpdateFenceRange,
 } from '@/features/walk-fence';
 
+import { WalkSideRail } from './ui/WalkSideRail';
+
 interface DraftCenter {
   lat: number;
   lng: number;
@@ -83,40 +85,45 @@ export function WalkPage() {
   };
 
   return (
-    // 헤더(h-14) 아래로 전체 폭을 채우는 네이버 지도 스타일 레이아웃
-    // (main의 max-w-5xl·padding을 벗어나기 위해 full-bleed 처리)
-    <div className="relative left-1/2 -my-6 flex h-[calc(100vh-3.5rem)] w-screen -translate-x-1/2 overflow-hidden bg-white">
-      {/* 왼쪽 사이드바 — 울타리 설정 (추후 산책 활동 섹션 추가 예정) */}
-      <aside className="flex w-[380px] shrink-0 flex-col overflow-y-auto border-r border-neutral-200 bg-white">
-        <div className="border-b border-neutral-200 px-5 py-4">
-          <h1 className="text-lg font-bold text-neutral-900">산책</h1>
-          <p className="mt-0.5 text-xs text-neutral-500">반려동물 안전 울타리를 설정하세요.</p>
-        </div>
-        <FenceControlPanel
-          pets={pets}
-          selectedPetId={selectedPetId}
-          onSelectPet={setSelectedPetId}
-          existingFence={existingFence}
-          draftCenter={draftCenter}
-          radius={radius}
-          onRadiusChange={setRadius}
-          fenceName={fenceName}
-          onFenceNameChange={setFenceName}
-          onCreate={handleCreate}
-          onUpdate={handleUpdate}
-          onToggle={handleToggle}
-          isSubmitting={isSubmitting}
-        />
-      </aside>
-
-      {/* 오른쪽 지도 영역 */}
-      <div className="relative flex-1">
+    // 네이버 지도 스타일: 지도가 화면 전체, 그 위에 둥근 레일 + 패널이 떠 있음
+    <div className="relative h-screen bg-neutral-100">
+      {/* 배경 전체를 채우는 지도 */}
+      <div className="absolute inset-0">
         <WalkMap
           boundaries={boundaries}
           draftCenter={draftCenter}
           draftRadius={radius}
           onMapClick={(lat, lng) => setDraftCenter({ lat, lng })}
         />
+      </div>
+
+      {/* 좌측 플로팅: 세로 레일 + 울타리 패널 */}
+      <div className="absolute inset-y-3 left-3 z-10 flex gap-3">
+        <WalkSideRail />
+
+        <aside className="flex w-[360px] flex-col overflow-hidden rounded-2xl bg-white shadow-md">
+          <div className="shrink-0 border-b border-neutral-200 px-5 py-4">
+            <h1 className="text-lg font-bold text-neutral-900">산책</h1>
+            <p className="mt-0.5 text-xs text-neutral-500">반려동물 안전 울타리를 설정하세요.</p>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            <FenceControlPanel
+              pets={pets}
+              selectedPetId={selectedPetId}
+              onSelectPet={setSelectedPetId}
+              existingFence={existingFence}
+              draftCenter={draftCenter}
+              radius={radius}
+              onRadiusChange={setRadius}
+              fenceName={fenceName}
+              onFenceNameChange={setFenceName}
+              onCreate={handleCreate}
+              onUpdate={handleUpdate}
+              onToggle={handleToggle}
+              isSubmitting={isSubmitting}
+            />
+          </div>
+        </aside>
       </div>
     </div>
   );

--- a/src/pages/walk/WalkPage.tsx
+++ b/src/pages/walk/WalkPage.tsx
@@ -6,6 +6,7 @@ import {
   WalkMap,
   useCreateFence,
   useFenceBoundaries,
+  useLiveLocation,
   useToggleFence,
   useUpdateFenceRange,
 } from '@/features/walk-fence';
@@ -84,6 +85,14 @@ export function WalkPage() {
     });
   };
 
+  // 선택한 펫의 실시간 위치 구독
+  const { location: liveLocation } = useLiveLocation(selectedPetId);
+  const selectedPetName = pets.find((pet) => pet.petId === selectedPetId)?.petName ?? '반려동물';
+
+  // 울타리가 켜져 있고 + 실제로 벗어났을 때만 이탈로 간주
+  const fenceActive = existingFence?.isActive ?? false;
+  const isOutsideFence = !!liveLocation && fenceActive && !liveLocation.insideFence;
+
   return (
     // 네이버 지도 스타일: 지도가 화면 전체, 그 위에 둥근 레일 + 패널이 떠 있음
     <div className="relative h-screen bg-neutral-100">
@@ -94,8 +103,20 @@ export function WalkPage() {
           draftCenter={draftCenter}
           draftRadius={radius}
           onMapClick={(lat, lng) => setDraftCenter({ lat, lng })}
+          livePosition={
+            liveLocation
+              ? { lat: liveLocation.latitude, lng: liveLocation.longitude, insideFence: !isOutsideFence }
+              : null
+          }
         />
       </div>
+
+      {/* 울타리 이탈 알림 배너 (울타리 켜진 경우에만) */}
+      {liveLocation && isOutsideFence && (
+        <div className="absolute left-1/2 top-4 z-20 -translate-x-1/2 rounded-full bg-red-500 px-4 py-2 text-sm font-semibold text-white shadow-lg">
+          ⚠️ {selectedPetName}이(가) 울타리를 벗어났어요! (약 {Math.round(liveLocation.distanceMeter)}m)
+        </div>
+      )}
 
       {/* 좌측 플로팅: 세로 레일 + 울타리 패널 */}
       <div className="absolute inset-y-3 left-3 z-10 flex gap-3">

--- a/src/pages/walk/WalkPage.tsx
+++ b/src/pages/walk/WalkPage.tsx
@@ -1,9 +1,112 @@
-import { WalkMap } from '@/features/walk-fence';
+import { useMemo, useState } from 'react';
+
+import { usePetList } from '@/features/auth';
+import {
+  FenceControlPanel,
+  WalkMap,
+  useCreateFence,
+  useFenceBoundaries,
+  useToggleFence,
+  useUpdateFenceRange,
+} from '@/features/walk-fence';
+
+interface DraftCenter {
+  lat: number;
+  lng: number;
+}
+
+const EMPTY_BOUNDARIES: never[] = [];
 
 export function WalkPage() {
+  const { data: boundariesData } = useFenceBoundaries();
+  const { data: petListData } = usePetList();
+  const createFence = useCreateFence();
+  const toggleFence = useToggleFence();
+  const updateFenceRange = useUpdateFenceRange();
+
+  const boundaries = boundariesData?.boundaries ?? EMPTY_BOUNDARIES;
+  const pets = petListData?.pets ?? [];
+
+  const [selectedPetId, setSelectedPetId] = useState<number | null>(null);
+  const [draftCenter, setDraftCenter] = useState<DraftCenter | null>(null);
+  const [radius, setRadius] = useState(500);
+  const [fenceName, setFenceName] = useState('');
+
+  // 선택한 펫의 기존 울타리 (있으면 수정 모드, 없으면 생성 모드)
+  const existingFence = useMemo(
+    () => (selectedPetId != null ? (boundaries.find((fence) => fence.petId === selectedPetId) ?? null) : null),
+    [boundaries, selectedPetId],
+  );
+
+  // 펫/울타리가 바뀌면 입력값 동기화 (effect 대신 렌더 중 조정 — React 권장 패턴)
+  const formKey = `${selectedPetId ?? ''}:${existingFence?.fenceId ?? ''}`;
+  const [syncedKey, setSyncedKey] = useState(formKey);
+  if (formKey !== syncedKey) {
+    setSyncedKey(formKey);
+    setRadius(existingFence ? existingFence.radius : 500);
+    setFenceName(existingFence ? existingFence.fenceName : '');
+    setDraftCenter(null);
+  }
+
+  const isSubmitting = createFence.isPending || toggleFence.isPending || updateFenceRange.isPending;
+
+  const handleCreate = () => {
+    if (selectedPetId == null || !draftCenter) return;
+    createFence.mutate({
+      petId: selectedPetId,
+      centerLatitude: draftCenter.lat,
+      centerLongitude: draftCenter.lng,
+      radius,
+      fenceName: fenceName.trim(),
+    });
+  };
+
+  const handleUpdate = () => {
+    if (!existingFence) return;
+    updateFenceRange.mutate({
+      fenceId: existingFence.fenceId,
+      payload: {
+        centerLatitude: draftCenter?.lat ?? existingFence.center.latitude,
+        centerLongitude: draftCenter?.lng ?? existingFence.center.longitude,
+        radius,
+        fenceName: fenceName.trim() || existingFence.fenceName,
+      },
+    });
+  };
+
+  const handleToggle = () => {
+    if (!existingFence) return;
+    toggleFence.mutate({
+      fenceId: existingFence.fenceId,
+      payload: { fenceIsActive: !existingFence.isActive },
+    });
+  };
+
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-6">
-      <WalkMap />
+    <div className="mx-auto w-full max-w-6xl px-4 py-6">
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <WalkMap
+          boundaries={boundaries}
+          draftCenter={draftCenter}
+          draftRadius={radius}
+          onMapClick={(lat, lng) => setDraftCenter({ lat, lng })}
+        />
+        <FenceControlPanel
+          pets={pets}
+          selectedPetId={selectedPetId}
+          onSelectPet={setSelectedPetId}
+          existingFence={existingFence}
+          draftCenter={draftCenter}
+          radius={radius}
+          onRadiusChange={setRadius}
+          fenceName={fenceName}
+          onFenceNameChange={setFenceName}
+          onCreate={handleCreate}
+          onUpdate={handleUpdate}
+          onToggle={handleToggle}
+          isSubmitting={isSubmitting}
+        />
+      </div>
     </div>
   );
 }

--- a/src/pages/walk/WalkPage.tsx
+++ b/src/pages/walk/WalkPage.tsx
@@ -55,26 +55,36 @@ export function WalkPage() {
 
   const handleCreate = () => {
     if (selectedPetId == null || !draftCenter) return;
-    createFence.mutate({
-      petId: selectedPetId,
-      centerLatitude: draftCenter.lat,
-      centerLongitude: draftCenter.lng,
-      radius,
-      fenceName: fenceName.trim(),
-    });
+    createFence.mutate(
+      {
+        petId: selectedPetId,
+        centerLatitude: draftCenter.lat,
+        centerLongitude: draftCenter.lng,
+        radius,
+        fenceName: fenceName.trim(),
+      },
+      {
+        onSuccess: () => setDraftCenter(null), // 저장 후 미리보기 원 제거
+      },
+    );
   };
 
   const handleUpdate = () => {
     if (!existingFence) return;
-    updateFenceRange.mutate({
-      fenceId: existingFence.fenceId,
-      payload: {
-        centerLatitude: draftCenter?.lat ?? existingFence.center.latitude,
-        centerLongitude: draftCenter?.lng ?? existingFence.center.longitude,
-        radius,
-        fenceName: fenceName.trim() || existingFence.fenceName,
+    updateFenceRange.mutate(
+      {
+        fenceId: existingFence.fenceId,
+        payload: {
+          centerLatitude: draftCenter?.lat ?? existingFence.center.latitude,
+          centerLongitude: draftCenter?.lng ?? existingFence.center.longitude,
+          radius,
+          fenceName: fenceName.trim() || existingFence.fenceName,
+        },
       },
-    });
+      {
+        onSuccess: () => setDraftCenter(null), // 저장 후 미리보기 원 제거
+      },
+    );
   };
 
   const handleToggle = () => {

--- a/src/pages/walk/ui/WalkSideRail.tsx
+++ b/src/pages/walk/ui/WalkSideRail.tsx
@@ -1,0 +1,122 @@
+import { Link, NavLink } from 'react-router-dom';
+
+import profileDefaultIllustration from '@/features/auth/assets/profile-default.svg';
+import { useCurrentUser } from '@/features/auth/model/useCurrentUser';
+import DoDoLogo from '@/shared/assets/images/Logo_light.svg?react';
+import { useIsLoggedIn } from '@/widgets/header';
+
+interface IconProps {
+  className?: string;
+}
+
+function PawIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="5.5" cy="9" r="1.6" />
+      <circle cx="9.5" cy="6" r="1.6" />
+      <circle cx="14.5" cy="6" r="1.6" />
+      <circle cx="18.5" cy="9" r="1.6" />
+      <path d="M12 11c-2.5 0-4.5 2-5.2 4.2-.5 1.6.8 3 2.4 2.6 1-.2 1.8-.5 2.8-.5s1.8.3 2.8.5c1.6.4 2.9-1 2.4-2.6C16.5 13 14.5 11 12 11Z" />
+    </svg>
+  );
+}
+
+function ChatIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M21 11.5a8.4 8.4 0 0 1-8.5 8.5 8.6 8.6 0 0 1-3.9-.9L3 21l1.9-5.6A8.5 8.5 0 1 1 21 11.5Z" />
+    </svg>
+  );
+}
+
+function UserIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
+    </svg>
+  );
+}
+
+const NAV_ITEMS = [
+  { to: '/walk', label: '산책', Icon: PawIcon },
+  { to: '/community', label: '커뮤니티', Icon: ChatIcon },
+  { to: '/my', label: '마이도도', Icon: UserIcon },
+];
+
+const itemClass = ({ isActive }: { isActive: boolean }) =>
+  [
+    'flex w-full flex-col items-center gap-1 rounded-xl py-2 text-[11px] font-medium transition-colors',
+    isActive ? 'bg-brand/10 text-brand' : 'text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800',
+  ].join(' ');
+
+function RailProfile() {
+  const { profileUrl } = useCurrentUser();
+  const resolvedUrl = profileUrl?.trim() || profileDefaultIllustration;
+
+  return (
+    <Link
+      to="/my"
+      aria-label="마이도도"
+      className="overflow-hidden rounded-full border border-neutral-200 transition-opacity hover:opacity-90"
+    >
+      <img src={resolvedUrl} alt="" className="h-9 w-9 object-cover" draggable={false} />
+    </Link>
+  );
+}
+
+export function WalkSideRail() {
+  const isLoggedIn = useIsLoggedIn();
+
+  return (
+    <nav className="flex h-full w-20 shrink-0 flex-col items-center gap-2 rounded-2xl bg-white px-2 py-4 shadow-md">
+      <Link to="/" aria-label="DoDo 홈" className="mb-2 flex items-center justify-center">
+        <DoDoLogo className="h-6 w-auto max-w-full" />
+      </Link>
+
+      <div className="flex w-full flex-1 flex-col items-center gap-1.5">
+        {NAV_ITEMS.map(({ to, label, Icon }) => (
+          <NavLink key={to} to={to} end={to === '/walk'} className={itemClass}>
+            <Icon className="h-6 w-6" />
+            <span>{label}</span>
+          </NavLink>
+        ))}
+      </div>
+
+      {isLoggedIn ? (
+        <RailProfile />
+      ) : (
+        <Link to="/auth" className="text-[11px] font-medium text-neutral-500 hover:text-brand">
+          로그인
+        </Link>
+      )}
+    </nav>
+  );
+}

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -3,6 +3,7 @@ const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID;
 const OAUTH_REDIRECT_URI = import.meta.env.VITE_OAUTH_REDIRECT_URI;
 const NAVER_MAP_CLIENT_ID = import.meta.env.VITE_NAVER_MAP_CLIENT_ID;
+const WS_URL = import.meta.env.VITE_WS_URL;
 
 // 환경 변수 누락 방지
 const requiredEnv = {
@@ -11,6 +12,7 @@ const requiredEnv = {
   VITE_NAVER_CLIENT_ID: NAVER_CLIENT_ID,
   VITE_OAUTH_REDIRECT_URI: OAUTH_REDIRECT_URI,
   VITE_NAVER_MAP_CLIENT_ID: NAVER_MAP_CLIENT_ID,
+  VITE_WS_URL: WS_URL,
 };
 
 Object.entries(requiredEnv).forEach(([key, value]) => {
@@ -25,4 +27,5 @@ export const env = {
   NAVER_CLIENT_ID,
   OAUTH_REDIRECT_URI,
   NAVER_MAP_CLIENT_ID,
+  WS_URL,
 };

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -2,6 +2,7 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID;
 const OAUTH_REDIRECT_URI = import.meta.env.VITE_OAUTH_REDIRECT_URI;
+const NAVER_MAP_CLIENT_ID = import.meta.env.VITE_NAVER_MAP_CLIENT_ID;
 
 // 환경 변수 누락 방지
 const requiredEnv = {
@@ -9,6 +10,7 @@ const requiredEnv = {
   VITE_GOOGLE_CLIENT_ID: GOOGLE_CLIENT_ID,
   VITE_NAVER_CLIENT_ID: NAVER_CLIENT_ID,
   VITE_OAUTH_REDIRECT_URI: OAUTH_REDIRECT_URI,
+  VITE_NAVER_MAP_CLIENT_ID: NAVER_MAP_CLIENT_ID,
 };
 
 Object.entries(requiredEnv).forEach(([key, value]) => {
@@ -22,4 +24,5 @@ export const env = {
   GOOGLE_CLIENT_ID,
   NAVER_CLIENT_ID,
   OAUTH_REDIRECT_URI,
+  NAVER_MAP_CLIENT_ID,
 };

--- a/src/shared/lib/naver-map/loadNaverMap.ts
+++ b/src/shared/lib/naver-map/loadNaverMap.ts
@@ -1,0 +1,26 @@
+import { env } from '@/shared/config';
+
+let loadPromise: Promise<void> | null = null;
+
+/** 네이버 지도 스크립트를 한 번만 로드하고, 완료 시 resolve */
+export function loadNaverMap(): Promise<void> {
+  // 이미 로드 완료된 경우
+  if (window.naver?.maps) return Promise.resolve();
+
+  // 로딩 중이면 같은 Promise 재사용 (중복 로드 방지)
+  if (loadPromise) return loadPromise;
+
+  loadPromise = new Promise<void>((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${env.NAVER_MAP_CLIENT_ID}`;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      loadPromise = null; // 실패 시 다음에 재시도 가능하도록 초기화
+      reject(new Error('네이버 지도 스크립트를 불러오지 못했습니다.'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return loadPromise;
+}

--- a/src/shared/lib/naver-map/naver.d.ts
+++ b/src/shared/lib/naver-map/naver.d.ts
@@ -1,0 +1,23 @@
+// 네이버 지도(NCP Maps) 전역 타입 — 우선 지도 표시에 필요한 최소만 선언
+declare namespace naver.maps {
+  class LatLng {
+    constructor(lat: number, lng: number);
+  }
+
+  interface MapOptions {
+    center: LatLng;
+    zoom?: number;
+  }
+
+  class Map {
+    constructor(element: string | HTMLElement, options: MapOptions);
+    setCenter(latlng: LatLng): void;
+    setZoom(zoom: number): void;
+    destroy(): void;
+  }
+}
+
+// window.naver 로 접근할 수 있게 augment
+interface Window {
+  naver: typeof naver;
+}

--- a/src/shared/lib/naver-map/naver.d.ts
+++ b/src/shared/lib/naver-map/naver.d.ts
@@ -47,6 +47,29 @@ declare namespace naver.maps {
     setCenter(center: LatLng): void;
     setRadius(radius: number): void;
   }
+
+  class Point {
+    constructor(x: number, y: number);
+  }
+
+  interface MarkerIcon {
+    content: string;
+    anchor?: Point;
+  }
+
+  interface MarkerOptions {
+    map?: Map;
+    position: LatLng;
+    icon?: MarkerIcon | string;
+    title?: string;
+    clickable?: boolean;
+  }
+
+  class Marker {
+    constructor(options: MarkerOptions);
+    setMap(map: Map | null): void;
+    setPosition(position: LatLng): void;
+  }
 }
 
 // window.naver 로 접근할 수 있게 augment

--- a/src/shared/lib/naver-map/naver.d.ts
+++ b/src/shared/lib/naver-map/naver.d.ts
@@ -15,6 +15,25 @@ declare namespace naver.maps {
     setZoom(zoom: number): void;
     destroy(): void;
   }
+
+  interface CircleOptions {
+    map?: Map;
+    center: LatLng;
+    /** 반경(미터) */
+    radius: number;
+    strokeColor?: string;
+    strokeWeight?: number;
+    strokeOpacity?: number;
+    fillColor?: string;
+    fillOpacity?: number;
+  }
+
+  class Circle {
+    constructor(options: CircleOptions);
+    setMap(map: Map | null): void;
+    setCenter(center: LatLng): void;
+    setRadius(radius: number): void;
+  }
 }
 
 // window.naver 로 접근할 수 있게 augment

--- a/src/shared/lib/naver-map/naver.d.ts
+++ b/src/shared/lib/naver-map/naver.d.ts
@@ -2,6 +2,8 @@
 declare namespace naver.maps {
   class LatLng {
     constructor(lat: number, lng: number);
+    lat(): number;
+    lng(): number;
   }
 
   interface MapOptions {
@@ -9,10 +11,19 @@ declare namespace naver.maps {
     zoom?: number;
   }
 
+  /** 지도 이벤트 핸들 (해제 시 사용) */
+  type MapEventListener = object;
+
+  /** 클릭 등 포인터 이벤트 — coord에 클릭 좌표가 담김 */
+  interface PointerEvent {
+    coord: LatLng;
+  }
+
   class Map {
     constructor(element: string | HTMLElement, options: MapOptions);
     setCenter(latlng: LatLng): void;
     setZoom(zoom: number): void;
+    addListener(eventName: string, listener: (event: PointerEvent) => void): MapEventListener;
     destroy(): void;
   }
 
@@ -24,6 +35,8 @@ declare namespace naver.maps {
     strokeColor?: string;
     strokeWeight?: number;
     strokeOpacity?: number;
+    /** 'solid' | 'shortdash' | 'dash' 등 */
+    strokeStyle?: string;
     fillColor?: string;
     fillOpacity?: number;
   }

--- a/src/shared/lib/react-query/queryKey.ts
+++ b/src/shared/lib/react-query/queryKey.ts
@@ -60,4 +60,9 @@ export const queryKeys = {
         params?.sort ?? 'petWeightsMeasuredAt,desc',
       ] as const,
   },
+  fence: {
+    boundaries: () => ['fence', 'boundaries'] as const,
+    boundary: (fenceId: number) => ['fence', fenceId, 'boundary'] as const,
+    status: (petId: number) => ['fence', petId, 'status'] as const,
+  },
 } as const;

--- a/src/shared/lib/socket/stompClient.ts
+++ b/src/shared/lib/socket/stompClient.ts
@@ -1,0 +1,23 @@
+import { Client } from '@stomp/stompjs';
+
+import { env } from '@/shared/config';
+import { getAccessToken } from '@/shared/lib/auth/token';
+
+/** 설정이 끝난 STOMP 클라이언트를 생성 (구독은 사용하는 쪽에서) */
+export function createStompClient(): Client {
+  const client = new Client({
+    brokerURL: env.WS_URL, // wss://... 로 직접 연결 (SockJS 미사용)
+    reconnectDelay: 5000, // 연결 끊기면 5초 후 자동 재연결
+    heartbeatIncoming: 10000, // 서버 ↔ 클라이언트 연결 살아있는지 확인(10초)
+    heartbeatOutgoing: 10000,
+    beforeConnect: () => {
+      // 연결 직전마다 최신 토큰을 헤더에 실음 (재연결 시 갱신된 토큰 반영)
+      // 생성 시점에 넣으면 토큰 만료 시 갱신된 토큰이 반영되지 않음
+      client.connectHeaders = {
+        Authorization: `Bearer ${getAccessToken() ?? ''}`,
+      };
+    },
+  });
+
+  return client;
+}

--- a/src/widgets/header/index.ts
+++ b/src/widgets/header/index.ts
@@ -1,1 +1,2 @@
 export { Header } from './ui/Header';
+export { useIsLoggedIn } from './model/useIsLoggedIn';

--- a/yarn.lock
+++ b/yarn.lock
@@ -670,6 +670,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz#beacb356412eef5dc0164e9edfee51c563732054"
   integrity sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==
 
+"@stomp/stompjs@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@stomp/stompjs/-/stompjs-7.3.0.tgz#5655b93e086a0be684291424c5bc8c92949b33ee"
+  integrity sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==
+
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz#4001f5d5dd87fa13303e36ee106e3ff3a7eb8b22"


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

산책 페이지에 반려동물 안전 울타리(지오펜스)와 실시간 위치 추적 기능을 구현했습니다.

**지도 & 레이아웃**
- 네이버 지도(NCP Maps) 연동 (스크립트 로더 + 전역 타입)
- 네이버 지도 스타일 전체화면 레이아웃 (상단 헤더 숨김, 좌측 세로 레일 + 둥근 플로팅 패널)

**울타리(REST)**
- Fence REST API 6종 연동 (생성/상태조회/토글/범위수정/경계조회/경계목록)
- 지도 클릭으로 중심 지정 + 미리보기 원, 울타리 생성/수정/ON·OFF 조작 UI
- 울타리 경계를 지도에 원으로 표시, 펫 이름 라벨 노출

**실시간 위치(WebSocket / STOMP)**
- @stomp/stompjs 기반 STOMP 클라이언트 (자동 재연결, 연결 직전 토큰 주입)
- `useLiveLocation` 훅: `/sub/fence/location/{petId}` 구독 → 실시간 좌표 수신
- 실시간 위치 마커 표시 및 울타리 이탈 시 경고 배너 (울타리 활성 시에만)

<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #62 

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

<img width="2522" height="1460" alt="image" src="https://github.com/user-attachments/assets/ea29e512-31f1-4a8b-a79b-f416a876dcba" />


<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 신규 환경변수: `VITE_NAVER_MAP_CLIENT_ID`, `VITE_WS_URL` (`.env` 설정 필요)
- WebSocket 구독 경로는 `/sub/fence/location/{petId}` (앞 슬래시 포함)로 구현
- `getFenceBoundary`(단일 경계 조회), `useFenceStatus`는 현재 화면에선 미사용이나 추후 활용 위해 유지
- 산책 페이지는 `/walk`에서만 헤더를 숨기고 전체화면으로 렌더 (다른 페이지 영향 없음)